### PR TITLE
 Support for external fonts

### DIFF
--- a/Common/Settings.cpp
+++ b/Common/Settings.cpp
@@ -28,6 +28,11 @@
 
 VISIT_BOOL_SETTINGS(SET_BOOL_DEFAULTS);
 
+#define SET_INT_DEFAULTS(name, value) \
+	int name = value;
+
+VISIT_INT_SETTINGS(SET_INT_DEFAULTS);
+
 // Forward declarations
 bool SetValue(char* name);
 bool IsValidSettings(char* name, char* value);
@@ -43,6 +48,11 @@ void __stdcall ParseCallback(char* lpName, char* lpValue)
 	if (!_strcmpi(lpName, #name)) name = SetValue(lpValue);
 
 	VISIT_BOOL_SETTINGS(GET_BOOL_VALUES);
+
+#define GET_INT_VALUES(name, unused) \
+	if (!_strcmpi(lpName, #name)) name = atoi(lpValue);
+
+	VISIT_INT_SETTINGS(GET_INT_VALUES);
 }
 
 // Set booloean value from string (file)

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -27,13 +27,30 @@
 	visit(UseCustomModFolder, true) \
 	visit(WhiteShaderFix, true) \
 	visit(WidescreenFix, true) \
-	visit(WndModeBorder, true)
+	visit(WndModeBorder, true) \
+	visit(UseCustomFonts, false) \
+	visit(DisableEnlargedText, false)
+
+#define VISIT_INT_SETTINGS(visit) \
+	visit(CustomFontCol, 100) \
+	visit(CustomFontRow, 14) \
+	visit(CustomFontCharWidth, 20) \
+	visit(CustomFontCharHeight, 32) \
+	visit(NormalFontWidth, 20) \
+	visit(NormalFontHeight, 30) \
+	visit(SmallFontWidth, 14) \
+	visit(SmallFontHeight, 24)
 
 // Configurable setting defaults
 #define DECLARE_BOOL_SETTINGS(name, unused) \
 	extern bool name;
 
 VISIT_BOOL_SETTINGS(DECLARE_BOOL_SETTINGS);
+
+#define DECLARE_INT_SETTINGS(name, unused) \
+	extern int name;
+
+VISIT_INT_SETTINGS(DECLARE_INT_SETTINGS);
 
 typedef void(__stdcall* NV)(char* name, char* value);
 

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -57,6 +57,18 @@ SteamCrashFix = 1 // Prevents a crash when Steam controller configuration is use
 IncreaseNoiseEffectRes = 512 // Use 128 and above to increase noise effect resolution.
 FullscreenImages = 1 // Crops letterboxing to fill the screen.
 
+[FONTS]
+UseCustomFonts = 1 // Loads 'font000.tga' file located in 'sh2e\font' folder as font texture and "fontwdata.bin" as width data for the first 224 chars.
+DisableEnlargedText = 1 // Disables enlarged, floating save/load menu text.
+CustomFontCol = 100 // Number of chars in column on font texture.
+CustomFontRow = 14 // Number of chars in row on font texture.
+CustomFontCharWidth = 20 // Width of single char on font texture.
+CustomFontCharHeight = 32 // Height of single char on font texture.
+NormalFontWidth = 20 // Width of single char in game.
+NormalFontHeight = 30 // Height of single char in game.
+SmallFontWidth = 16 // Width of single char in game.
+SmallFontHeight = 24 // Height of single char in game.
+
 // Nemesis2000 Fog Fix
 [FOG]
 fog_custom_on = 1 // 0 - Off, 1 - On

--- a/Patches/Fonts.cpp
+++ b/Patches/Fonts.cpp
@@ -1,0 +1,226 @@
+/**
+* Copyright (C) 2018 Elisha Riedlinger
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+#include "Common\Settings.h"
+
+enum TGA_image_type {
+	CMI = 1,		// colour map image
+	RGBA,			// RGB(A) uncompressed
+	GREY,			// greyscale uncompressed
+	GREY_RLE = 9,	// greyscale RLE (compressed)
+	RGBA_RLE,		// RGB(A) RLE (compressed)
+};
+
+#pragma pack(push, 1)
+typedef struct {
+	BYTE id;				// id
+	BYTE color_map_type;	// colour map type
+	BYTE image_type;		// image type
+	WORD cm_first_entry;	// colour map first entry
+	WORD cm_length;			// colour map length
+	BYTE map_entry_size;	// map entry size, colour map depth (16, 24 , 32)
+	WORD h_origin;			// horizontal origin
+	WORD v_origin;			// vertical origin
+	WORD width;				// width
+	WORD height;			// height
+	BYTE pixel_depth;		// pixel depth
+	BYTE image_desc;		// image descriptor
+} TGA_FILEHEADER;
+#pragma pack(pop)
+
+using namespace std;
+
+// Predefined code bytes
+constexpr BYTE DFontFuncBlockA[] = { 0x00, 0x83, 0xEC, 0x24, 0x85, 0xC0, 0x56, 0x57, 0x0F, 0x85, 0x12, 0x01 };
+constexpr BYTE DFontFuncBlockB[] = { 0x19, 0x00, 0x00, 0x00, 0xF7, 0xFE, 0xC1, 0xE7, 0x04, 0x66, 0x89, 0x79, 0x02, 0xC1, 0xE3, 0x04 };
+constexpr BYTE DFontFuncBlockC[] = { 0xBE, 0x19, 0x00, 0x00, 0x00, 0xF7, 0xFE, 0x83, 0xC4, 0x04, 0x6B, 0xD2, 0x16, 0x66, 0x89, 0x51, 0x08, 0xC1, 0xE0, 0x05 };
+constexpr BYTE DFontFuncBlockD[] = { 0x00, 0x5F, 0x7F, 0x9F, 0xBF, 0xDF, 0xFF, 0x1F, 0x00, 0x00, 0x00, 0x00 };
+
+unsigned int fontTexWidth = 550;
+unsigned int fontTexHeight = 544;
+float fontTexScaleW = 1.0f;
+float fontTexScaleH = 1.0f;
+BYTE charW = 22;
+BYTE charH = 32;
+BYTE charIX = 100;
+BYTE charIY = 150;
+WORD nFontW = 20;
+WORD nFontH = 30;
+WORD sFontW = 16;
+WORD sFontH = 24;
+
+TGA_FILEHEADER tga;
+BYTE *fontData;
+
+void UpdateFontTex(BYTE *ptr, int size)
+{
+	Logging::Log() << __FUNCTION__ << " - address: " << (DWORD)ptr << ", size: " << size;
+
+	if (fontData)
+		memcpy(ptr, fontData, size);
+
+	return;
+}
+
+int ReturnFontIdx(int fontSize, WORD charID)
+{
+	int charMax = (charIX * charIY) / 2;
+
+	if (charID > charMax)
+		return 0;
+
+	return charID + fontSize * charMax;
+}
+
+void UpdateCustomFonts()
+{
+	// Find address for font decode function
+	void *DFontAddrA = CheckMultiMemoryAddress((void*)0x004809F4, (void*)0x00480C90, (void*)0x00480EA4, (void*)DFontFuncBlockA, sizeof(DFontFuncBlockA));
+	void *DFontAddrB = CheckMultiMemoryAddress((void*)0x0047E270, (void*)0x0047E510, (void*)0x0047E720, (void*)DFontFuncBlockB, sizeof(DFontFuncBlockB));
+
+	// Search for address
+	if (!DFontAddrA) {
+		Logging::Log() << __FUNCTION__ << " searching for memory address DFontAddrA!";
+		DFontAddrA = GetAddressOfData(DFontFuncBlockA, sizeof(DFontFuncBlockA), 4, 0x00480000, 1800);
+	}
+
+	if (!DFontAddrB) {
+		Logging::Log() << __FUNCTION__ << " searching for memory address DFontAddrB!";
+		DFontAddrB = GetAddressOfData(DFontFuncBlockB, sizeof(DFontFuncBlockB), 4, 0x00470000, 1800);
+	}
+
+	// Address found
+	if (!DFontAddrA || !DFontAddrB) {
+		Logging::Log() << __FUNCTION__ << " Error: Could not find font decode function address in memory!";
+		return;
+	}
+
+	charIX = (BYTE)CustomFontCol;
+	charIY = (BYTE)CustomFontRow;
+	charW = (BYTE)CustomFontCharWidth;
+	charH = (BYTE)CustomFontCharHeight;
+	nFontW = (WORD)NormalFontWidth;
+	nFontH = (WORD)NormalFontHeight;
+	sFontW = (WORD)SmallFontWidth;
+	sFontH = (WORD)SmallFontHeight;
+
+	ifstream file("sh2e/font/font000.tga", ios::in | ios::binary | ios::ate);
+
+	if (file.is_open()) {
+		file.seekg(0, ios::beg);
+		file.read((char *)&tga, sizeof(TGA_FILEHEADER));
+
+		if (tga.image_type != RGBA || tga.pixel_depth != 32 || tga.image_desc != 40) {
+			Logging::Log() << __FUNCTION__ << " Error: Unsupported tga format!";
+			file.close();
+			return;
+		}
+
+		fontTexWidth = tga.width;
+		fontTexHeight = tga.height;
+		int texSize = fontTexWidth * fontTexHeight * 4;
+		fontData = new BYTE[texSize];
+
+		file.seekg(sizeof(TGA_FILEHEADER) + tga.cm_length * 4, ios::beg);
+		file.read((char *)fontData, texSize);
+		file.close();
+	} else {
+		Logging::Log() << __FUNCTION__ << " Error: Could not find font file";
+		return;
+	}
+
+	fontTexScaleW = 550.0f / (float)(charIX * charW);
+	fontTexScaleH = 544.0f / (float)(charIY * charH);
+
+	UpdateMemoryAddress((void *)((BYTE*)DFontAddrA + 0x17), (void *)&fontTexWidth, 4);
+	UpdateMemoryAddress((void *)((BYTE*)DFontAddrA + 0x1C), (void *)&fontTexHeight, 4);
+	UpdateMemoryAddress((void *)((BYTE*)DFontAddrA + 0x31), (void *)&fontTexScaleW, 4);
+	UpdateMemoryAddress((void *)((BYTE*)DFontAddrA + 0x3B), (void *)&fontTexScaleH, 4);
+
+	BYTE codeA[] = { 0x51, 0x57, 0xBA, 0xEF, 0xBE, 0xAD, 0xDE, 0xFF, 0xD2, 0x83, 0xc4, 0x08, 0x90, 0x90, 0x90, 0x90 };
+	codeA[3] = (BYTE)((DWORD)*UpdateFontTex & 0xFF);
+	codeA[4] = (BYTE)((DWORD)*UpdateFontTex >> 8);
+	codeA[5] = (BYTE)((DWORD)*UpdateFontTex >> 16);
+	codeA[6] = (BYTE)((DWORD)*UpdateFontTex >> 24);
+	UpdateMemoryAddress((void *)((BYTE*)DFontAddrA + 0xFE), (void *)&codeA, sizeof(codeA));
+
+	BYTE codeB[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x8B, 0x54, 0x24, 0x30, 0x52, 0xBA, 0xEF, 0xBE, 0xAD, 0xDE };
+	codeB[19] = (BYTE)((DWORD)*ReturnFontIdx & 0xFF);
+	codeB[20] = (BYTE)((DWORD)*ReturnFontIdx >> 8);
+	codeB[21] = (BYTE)((DWORD)*ReturnFontIdx >> 16);
+	codeB[22] = (BYTE)((DWORD)*ReturnFontIdx >> 24);
+	UpdateMemoryAddress((void *)((BYTE*)DFontAddrA + 0x120), (void *)&codeB, sizeof(codeB));
+
+	BYTE codeC[] = { 0x50, 0xFF, 0xD2, 0x83, 0xC4, 0x08, 0x5F, 0x5E, 0x83, 0xC4, 0x24, 0xC3 };
+	UpdateMemoryAddress((void *)((BYTE*)DFontAddrA + 0x120 + sizeof(codeB) + 5), (void *)&codeC, sizeof(codeC));
+	
+	UpdateMemoryAddress((void *)((BYTE*)DFontAddrB), (void *)&charIX, 1);
+	BYTE codeD[] = { 0x6B, 0xC0, 0x05 };
+	if (DisableEnlargedText) {
+		codeD[2] = 0;
+		UpdateMemoryAddress((void *)((BYTE*)DFontAddrB + 0x15), (void *)&codeD[2], 1);
+		UpdateMemoryAddress((void *)((BYTE*)DFontAddrB + 0x16), (void *)&codeD, sizeof(codeD));
+	} else {
+		codeD[2] = (BYTE)charH;
+		UpdateMemoryAddress((void *)((BYTE*)DFontAddrB + 0x15), (void *)&charW, 1);
+		UpdateMemoryAddress((void *)((BYTE*)DFontAddrB + 0x16), (void *)&codeD, sizeof(codeD));
+	}
+	codeD[2] = (BYTE)charH;
+
+	void *DFontAddrC = GetAddressOfData(DFontFuncBlockC, sizeof(DFontFuncBlockC), 1, 0x0047E000, 2000);
+
+	if (DFontAddrC) {
+		UpdateMemoryAddress((void *)((BYTE*)DFontAddrC + 1), (void *)&charIX, 1);
+		UpdateMemoryAddress((void *)((BYTE*)DFontAddrC + 12), (void *)&charW, 1);
+		UpdateMemoryAddress((void *)((BYTE*)DFontAddrC + 17), (void *)&codeD, sizeof(codeD));
+
+		void *DFontAddrD = GetAddressOfData(DFontFuncBlockC, sizeof(DFontFuncBlockC), 1, (DWORD)DFontAddrC + sizeof(DFontFuncBlockC), 2000);
+
+		if (DFontAddrD) {
+			UpdateMemoryAddress((void *)((BYTE*)DFontAddrD + 1), (void *)&charIX, 1);
+			UpdateMemoryAddress((void *)((BYTE*)DFontAddrD + 12), (void *)&charW, 1);
+			UpdateMemoryAddress((void *)((BYTE*)DFontAddrD + 17), (void *)&codeD, sizeof(codeD));
+		}
+	}
+
+	void *DFontAddrE = CheckMultiMemoryAddress((void*)0x008038A8, (void*)0x00807490, (void*)0x00806490, (void*)DFontFuncBlockD, sizeof(DFontFuncBlockD));
+
+	if (DFontAddrE) {
+		UpdateMemoryAddress((void *)((BYTE*)DFontAddrE - 0x10), (void *)&nFontW, 2);
+		UpdateMemoryAddress((void *)((BYTE*)DFontAddrE - 0x10 + 2), (void *)&nFontH, 2);
+		UpdateMemoryAddress((void *)((BYTE*)DFontAddrE - 0x10 + 4), (void *)&sFontW, 2);
+		UpdateMemoryAddress((void *)((BYTE*)DFontAddrE - 0x10 + 6), (void *)&sFontH, 2);
+			
+		ifstream wfile("sh2e/font/fontwdata.bin", ios::in | ios::binary | ios::ate);
+
+		if (wfile.is_open()) {
+			BYTE *fwidth = new BYTE[0xE0];
+			wfile.seekg(0, ios::beg);
+			wfile.read((char *)fwidth, 0xE0);
+			UpdateMemoryAddress((void *)(*(DWORD *)((BYTE*)DFontAddrE - 8) + 16), (void *)fwidth, 0xE0);
+			wfile.read((char *)fwidth, 0xE0);
+			UpdateMemoryAddress((void *)(*(DWORD *)((BYTE*)DFontAddrE - 4) + 16), (void *)fwidth, 0xE0);
+			wfile.close();
+			delete[] fwidth;
+		} else {
+			Logging::Log() << __FUNCTION__ << " Could not find font width data file";
+		}
+	}
+}

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -12,3 +12,4 @@ void UpdateRowboatAnimation();
 void UpdateCatacombsMeatRoom();
 void UpdateRedCrossInCutscene();
 void UpdateFogParameters();
+void UpdateCustomFonts();

--- a/Resources/BuildNo.rc
+++ b/Resources/BuildNo.rc
@@ -1,1 +1,1 @@
-#define BUILD_NUMBER 1306 
+#define BUILD_NUMBER 1307 

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -193,6 +193,12 @@ bool APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID lpReserved)
 			UpdateRedCrossInCutscene();
 		}
 
+		// Loads font texture form tga file
+		if (UseCustomFonts)
+		{
+			UpdateCustomFonts();
+		}
+
 		// Load Nemesis2000's Fog Fix
 		if (Nemesis2000FogFix)
 		{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -171,7 +171,6 @@ copy /Y "$(ProjectDir)Resources\SilentHill2.WidescreenFix.dat" "$(TargetDir)$(Ta
       <ModuleDefinitionFile>Wrappers\wrapper.def</ModuleDefinitionFile>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\lib\x86;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\atlmfc\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
       <Command>cmd /c "@echo off &amp;&amp; cd /D ""$(ProjectDir)"" &amp;&amp; if not exist Resources\BuildNo.rc echo #define BUILD_NUMBER 0 &gt;Resources\BuildNo.rc"

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -42,6 +42,7 @@
     <ClCompile Include="Patches\DrawDistance.cpp" />
     <ClCompile Include="Patches\CatacombsMeatRoom.cpp" />
     <ClCompile Include="Patches\FogAdjustments.cpp" />
+    <ClCompile Include="Patches\Fonts.cpp" />
     <ClCompile Include="Patches\NoCDPatch.cpp" />
     <ClCompile Include="Patches\PS2NoiseFilter.cpp" />
     <ClCompile Include="dllmain.cpp" />
@@ -170,6 +171,7 @@ copy /Y "$(ProjectDir)Resources\SilentHill2.WidescreenFix.dat" "$(TargetDir)$(Ta
       <ModuleDefinitionFile>Wrappers\wrapper.def</ModuleDefinitionFile>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\lib\x86;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\atlmfc\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
       <Command>cmd /c "@echo off &amp;&amp; cd /D ""$(ProjectDir)"" &amp;&amp; if not exist Resources\BuildNo.rc echo #define BUILD_NUMBER 0 &gt;Resources\BuildNo.rc"

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -131,6 +131,9 @@
     <ClCompile Include="Patches\FogAdjustments.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\Fonts.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
This commit adds:
- Loading "sh2e\font\font000.tga" image which contains sets of two fonts and patching game to use it. If option `UseCustomFonts = 0` or image file is missing/format is wrong patches won't be loaded.
- Loading "sh2e\font\fontwdata.bin" as width data for the first 224 chars, for two sets of fonts (optional). The file contains width values in byte size. If it's missing default game's values will be used.
- Reading int values from *.ini file to get font's settings.