### PR TITLE
Replaced DirectInput force feedback with XInput vibration

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -36,7 +36,8 @@
 	visit(WidescreenFix, true) \
 	visit(WndModeBorder, true) \
 	visit(UseCustomFonts, false) \
-	visit(DisableEnlargedText, false)
+	visit(DisableEnlargedText, false) \
+	visit(XInputVibration, false)
 
 #define VISIT_INT_SETTINGS(visit) \
 	visit(CustomFontCol, 100) \
@@ -46,7 +47,8 @@
 	visit(NormalFontWidth, 20) \
 	visit(NormalFontHeight, 30) \
 	visit(SmallFontWidth, 14) \
-	visit(SmallFontHeight, 24)
+	visit(SmallFontHeight, 24) \
+	visit(PadNumber, 0)
 
 // Configurable setting defaults
 #define DECLARE_BOOL_SETTINGS(name, unused) \

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -5,6 +5,7 @@ AutoUpdateModule = 1 // Checks for updated versions of the SH2 Enhancement modul
 d3d8to9 = 1 // Causes Silent Hill 2 to use DirectX 9.
 UseCustomModFolder = 1 // Uses files in the 'sh2e' folder rather than the 'data' folder.
 WidescreenFix = 1 // Enables WidescreenFixesPack and sh2proxy module. See options below.
+XInputVibration = 1 // Replaces DirectInput based vibration with XInput based vibration.
 
 [GAME FIXES]
 CatacombsMeatRoomFix = 1 // Updates the color and lighting of the catacomb meat cold rooms to be more like the PS2.  This update also requires updated 'ps189.map' and 'ps193.map' files.
@@ -74,6 +75,9 @@ NormalFontWidth = 20 // Width of single char in game.
 NormalFontHeight = 30 // Height of single char in game.
 SmallFontWidth = 16 // Width of single char in game.
 SmallFontHeight = 24 // Height of single char in game.
+
+[XINPUT_VIBRATION]
+PadNumber = 0 // XInput pad ID to vibrate.
 
 // Nemesis2000 Fog Fix
 [FOG]

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -20,6 +20,7 @@ void UpdatePS2Flashlight();
 void UpdateHotelWater(DWORD *SH2_RoomID);
 void UpdateRoom312ShadowFix(DWORD *SH2_RoomID);
 void UpdateClosetCutscene(DWORD *SH2_CutsceneID, float *SH2_CutsceneCameraPos);
+void UpdateXInputVibration();
 
 // Varable forward declaration
 extern void *RoomIDAddr;

--- a/Patches/XInputVibration.cpp
+++ b/Patches/XInputVibration.cpp
@@ -1,0 +1,184 @@
+/**
+* Copyright (C) 2019 Adrian Zdanowicz
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+// We need to target older Windows, else Win8+ only xinput1_4 will be used
+#define WINVER 0x0501
+#define _WIN32_WINNT 0x0501
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Common\Utils.h"
+#include "Common\Settings.h"
+#include "Logging\Logging.h"
+
+#define DIRECTINPUT_VERSION 0x0800
+#include <dinput.h>
+#pragma comment(lib, "dxguid.lib")
+
+#include <Xinput.h>
+#pragma comment(lib, "xinput.lib")
+
+static LPDIRECTINPUTEFFECT originalDInputEffect = nullptr;
+
+// XInput -> DirectInput vibration effect wrapper
+
+// NOTE: This wrapper is very primitive, mostly because it's been tailored specifically for the game
+// Silent Hill 2 uses vibration in a very simple manner - submits a periodic wave at 100% force until stopped by the game
+// For this use case, we just need to implement Start and Stop
+class XInputEffect final : public IDirectInputEffect
+{
+public:
+	virtual HRESULT WINAPI QueryInterface(REFIID, LPVOID*) override
+	{
+		// Deliberately left unimplemented
+		return E_NOTIMPL;
+	}
+
+	virtual ULONG WINAPI AddRef(void) override
+	{
+		// Deliberately left unimplemented
+		return 0;
+	}
+
+	virtual ULONG WINAPI Release(void) override
+	{
+		// Deliberately left unimplemented
+		return 0;
+	}
+
+	virtual HRESULT WINAPI Initialize(HINSTANCE, DWORD, REFGUID) override
+	{
+		// Deliberately left unimplemented
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT WINAPI GetEffectGuid(LPGUID) override
+	{
+		// Deliberately left unimplemented
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT WINAPI GetParameters(LPDIEFFECT, DWORD) override
+	{
+		// Deliberately left unimplemented
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT WINAPI SetParameters(LPCDIEFFECT, DWORD) override
+	{
+		// Deliberately left empty, SH2 only submits 100% force to SetParameters
+		return DI_OK;
+	}
+
+	virtual HRESULT WINAPI Start(DWORD dwIterations, DWORD dwFlags) override
+	{
+		if ( !m_vibrating )
+		{
+			XINPUT_VIBRATION vib = { FixedVibrationIntensity, 0 };
+			XInputSetState( PadNumber, &vib );
+			m_vibrating = true;
+		}
+		return originalDInputEffect != nullptr ? originalDInputEffect->Start( dwIterations, dwFlags ) : DI_OK;
+	}
+
+	virtual HRESULT WINAPI Stop(void) override
+	{
+		if ( m_vibrating )
+		{
+			XINPUT_VIBRATION vib = { 0, 0 };
+			XInputSetState( PadNumber, &vib );
+			m_vibrating = false;
+		}
+
+		return originalDInputEffect != nullptr ? originalDInputEffect->Stop() : DI_OK;
+	}
+
+	virtual HRESULT WINAPI GetEffectStatus(LPDWORD) override
+	{
+		// Deliberately left unimplemented
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT WINAPI Download(void) override
+	{
+		// Deliberately left unimplemented
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT WINAPI Unload(void) override
+	{
+		// Deliberately left unimplemented
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT WINAPI Escape(LPDIEFFESCAPE) override
+	{
+		// Deliberately left unimplemented
+		return E_NOTIMPL;
+	}
+
+private:
+	static constexpr WORD FixedVibrationIntensity = 65535;
+	bool m_vibrating = false;
+} StubXInputEffect;
+
+
+int32_t* DInputGamepadType;
+LPDIRECTINPUTEFFECT* directInputEffect;
+
+void (*orgCreateDirectInputGamepad)();
+void CreateDirectInputGamepad_Hook()
+{
+	orgCreateDirectInputGamepad();
+
+	if ( *DInputGamepadType != 0 )
+	{
+		// If game already created an effect, store it so we can submit data to both DInput and XInput
+		originalDInputEffect = *directInputEffect;
+		*directInputEffect = &StubXInputEffect;
+		*DInputGamepadType = 2;
+	}
+}
+
+void UpdateXInputVibration()
+{
+	constexpr BYTE XIVibrationSearchBytes[] { 0x57, 0x33, 0xC0, 0xB9, 0x9F, 0x01, 0x00, 0x00 };
+	const DWORD CreateDIGamepadAddr = SearchAndGetAddresses(0x458B30, 0x458D90, 0x458D90, XIVibrationSearchBytes, sizeof(XIVibrationSearchBytes), 0x24);
+	if (CreateDIGamepadAddr == 0)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	// Read out a jump from under this address and replace it with a custom one
+	int32_t jmpAddress = 0;
+	memcpy( &jmpAddress, (void*)(CreateDIGamepadAddr + 1), sizeof(jmpAddress) );
+
+	orgCreateDirectInputGamepad = decltype(orgCreateDirectInputGamepad)(jmpAddress + CreateDIGamepadAddr + 5);
+	WriteJMPtoMemory( (BYTE*)CreateDIGamepadAddr, CreateDirectInputGamepad_Hook );
+
+
+	constexpr BYTE SetVibrationParametersSearchBytes[] { 0x83, 0xEC, 0x38, 0x83, 0xF8, 0x02, 0x75, 0x39 };
+	const DWORD SetVibrationParametersAddr = SearchAndGetAddresses(0x458005, 0x458265, 0x458265, SetVibrationParametersSearchBytes, sizeof(SetVibrationParametersSearchBytes), -0x5);
+	if (SetVibrationParametersAddr == 0)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	DInputGamepadType = *(int32_t**)(SetVibrationParametersAddr + 1);
+	directInputEffect = *(LPDIRECTINPUTEFFECT**)(SetVibrationParametersAddr + 0x34 + 1);
+}

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -219,6 +219,12 @@ bool APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID lpReserved)
 			UpdatePS2Flashlight();
 		}
 
+		// XInput based vibration
+		if (XInputVibration)
+		{
+			UpdateXInputVibration();
+		}
+
 		// Loads font texture form tga file
 		if (UseCustomFonts)
 		{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -54,6 +54,7 @@
     <ClCompile Include="Patches\Room312Shadow.cpp" />
     <ClCompile Include="Patches\RowboatAnimation.cpp" />
     <ClCompile Include="Patches\SfxPatch.cpp" />
+    <ClCompile Include="Patches\XInputVibration.cpp" />
     <ClCompile Include="Wrappers\d3d8to9.cpp" />
     <ClCompile Include="Wrappers\d3d8\d3d8wrapper.cpp" />
     <ClCompile Include="Wrappers\d3d8\IDirect3D8.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -152,6 +152,9 @@
     <ClCompile Include="Patches\EnhancedFlashlight.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\XInputVibration.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
This feature was made as kindly requested by Ratiocinator.

Reportedly, XInput Plus vibration broke completely at some point, so SH2 was left with no controller rumble at all. I spent some time trying to figure out why XI Plus broke, but with no success. Eventually, I noticed how simple SH2's rumble is and decided to just reimplement it with XInput.

A few notes:
1. Wrapper for `IDirectInputEffect` is extremely primitive and game specific. It literally is tailored for how SH2 is using vibration, with nothing else implemented.
2. I did **not** link the lib against DX SDK, so it is creating a dependency on `xinput9_1_0.dll`. This DLL ships by default with all Windows since WinXP, so no dependency on DirectX Redistributables is created.


If you have any doubts or suggestions about either the code or hooking style, please don't hesitate to ask.