### PR TITLE
Set EnableWndMode by default in .ini

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -15,7 +15,7 @@
 	visit(FixMissingWallChunks, true) \
 	visit(Fog2DFix, true) \
 	visit(FogParameterFix, true) \
-	visit(FullscreenWndMode, false) \
+	visit(FullscreenWndMode, true) \
 	visit(HalogenLightFix, true) \
 	visit(HotelWaterFix, true) \
 	visit(ImproveStorageSupport, true) \

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -11,7 +11,7 @@
 	visit(DisableRedCrossInCutScenes, true) \
 	visit(EnableSFXAddrHack, true) \
 	visit(EnableSelfShadows, false) \
-	visit(EnableWndMode, false) \
+	visit(EnableWndMode, true) \
 	visit(FixMissingWallChunks, true) \
 	visit(Fog2DFix, true) \
 	visit(FogParameterFix, true) \

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -41,8 +41,8 @@ WndModeBorder = 0 // Enables window border when WndMode is enabled.
 
 // ThirteenAG Silent Hill 2 WidescreenFixesPack
 [MAIN]
-ResX = 0 // Resolution width, leave at 0 to inherently size to your display's width
-ResY = 0 // Resolution height, leave at 0 to inherently size to your display's height
+ResX = 0 // Resolution width, set to 0 to inherently size to your display's width.
+ResY = 0 // Resolution height, set to 0 to inherently size to your display's height.
 FMVWidescreenMode = 1 // Cutscenes and movies will display better in widescreen.
 FMVWidescreenEnhancementPackCompatibility = 0 // Adds compatibility when using the FMV Enhancement Pack.
 Fix2D = 1 // Enable to set 2D images to their original full screen aspect ratio. Disable to stretch the images to fill the screen.

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -36,13 +36,13 @@ LoadFromScriptsOnly = 0 // Loads ASI plugins only from the 'scripts' and 'plugin
 
 [WINDOWED MODE]
 EnableWndMode = 1 // Enables forced windowed mode.
-FullscreenWndMode = 0 // Enables fullscreen windowed mode. Requires EnableWndMode = 1.
+FullscreenWndMode = 1 // Enables fullscreen windowed mode. Requires EnableWndMode = 1.
 WndModeBorder = 0 // Enables window border when WndMode is enabled.
 
 // ThirteenAG Silent Hill 2 WidescreenFixesPack
 [MAIN]
-ResX = 0 // Resolution width, 0 for default
-ResY = 0 // Resolution height, 0 for default
+ResX = 0 // Resolution width, leave at 0 to inherently size to your display's width
+ResY = 0 // Resolution height, leave at 0 to inherently size to your display's height
 FMVWidescreenMode = 1 // Cutscenes and movies will display better in widescreen.
 FMVWidescreenEnhancementPackCompatibility = 0 // Adds compatibility when using the FMV Enhancement Pack.
 Fix2D = 1 // Enable to set 2D images to their original full screen aspect ratio. Disable to stretch the images to fill the screen.

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -35,7 +35,7 @@ LoadPlugins = 0 // Loads ASI plugins
 LoadFromScriptsOnly = 0 // Loads ASI plugins only from the 'scripts' and 'plugins' folders.
 
 [WINDOWED MODE]
-EnableWndMode = 0 // Enables forced windowed mode.
+EnableWndMode = 1 // Enables forced windowed mode.
 FullscreenWndMode = 0 // Enables fullscreen windowed mode. Requires EnableWndMode = 1.
 WndModeBorder = 0 // Enables window border when WndMode is enabled.
 


### PR DESCRIPTION
(Cautiously dipping my toes into a pull request; first time doing this.)

Simply enables `EnableWndMode` by default for users who download the project. This fixes the issue of the `FastTransitions` mod having noticeable slow-down for AMD users when played in fullscreen mode.