### PR TITLE
Added DPadMovementFix

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -40,6 +40,7 @@
 	visit(UseCustomFonts, true) \
 	visit(DisableEnlargedText, true) \
 	visit(XInputVibration, true) \
+	visit(DPadMovementFix, true) \
 	visit(UseCustomExeStr, true) \
 	visit(UnlockJapLang, false)
 

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -6,6 +6,7 @@ d3d8to9 = 1 // Causes Silent Hill 2 to use DirectX 9.
 UseCustomModFolder = 1 // Uses files in the 'sh2e' folder rather than the 'data' folder.
 WidescreenFix = 1 // Enables WidescreenFixesPack and sh2proxy module. See options below.
 XInputVibration = 1 // Replaces DirectInput based vibration with XInput based vibration.
+DPadMovementFix = 1 // Allow movement with DPad
 UseCustomExeStr = 1 // Loads "exe_str.txt" file located in the "sh2e\text" folder as built-in strings. Restores the language selection in the Options menu.
 UnlockJapLang = 0 // Unlocks Japanese language in the Options menu. It is recommended to keep this disabled for now, as not all Japanese characters are currently supported.
 

--- a/Patches/DPadMovement.cpp
+++ b/Patches/DPadMovement.cpp
@@ -1,0 +1,104 @@
+/**
+* Copyright (C) 2019 Adrian Zdanowicz
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#define _USE_MATH_DEFINES // For cmath
+#include <Windows.h>
+#include "Common\Utils.h"
+#include "Common\Settings.h"
+#include "Logging\Logging.h"
+
+
+#define DIRECTINPUT_VERSION 0x0800
+#include <dinput.h>
+
+DIJOYSTATE2* dinputJoyState;
+
+static void (*orgProcessDInputData)(short*);
+void ProcessDInputData_Hook(short* out)
+{
+	DIJOYSTATE2& joystickState = *dinputJoyState;
+
+	const DWORD povAngle = joystickState.rgdwPOV[0];
+	const bool centered = LOWORD(povAngle) == 0xFFFF;
+	if ( !centered )
+	{
+		// Override analog values with DPad values
+		const double angleRadians = static_cast<double>(povAngle) * M_PI / (180.0 * 100.0);
+
+		joystickState.lX = static_cast<LONG>(std::sin(angleRadians) * 32767.0);
+		joystickState.lY = static_cast<LONG>(std::cos(angleRadians) * -32767.0);
+	}
+
+	orgProcessDInputData(out);
+}
+
+void __stdcall GetDeviceState_Hook(IDirectInputDevice8A* device)
+{
+	DIJOYSTATE2& joystickState = *dinputJoyState;
+	bool success = false;
+	if (SUCCEEDED(device->Acquire()))
+	{
+		if(SUCCEEDED(device->GetDeviceState(sizeof(joystickState), &joystickState)))
+		{
+			success = true;
+		}
+	}
+
+	if (!success)
+	{
+		memset(&joystickState, 0, sizeof(joystickState));
+		std::fill(std::begin(joystickState.rgdwPOV), std::end(joystickState.rgdwPOV), DWORD(-1));
+	}
+}
+
+void UpdateDPadMovement()
+{
+	constexpr BYTE PollDInputDevicesSearchBytes[] { 0x33, 0xDB, 0x3B, 0xC3, 0x74, 0x33, 0x8B, 0x08 };
+	const DWORD PollDInputDevicesAddr = SearchAndGetAddresses(0x45893B, 0x458B9B, 0x458B9B, PollDInputDevicesSearchBytes, sizeof(PollDInputDevicesSearchBytes), -0xB);
+	if (PollDInputDevicesAddr == 0)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	dinputJoyState = *(DIJOYSTATE2**)(PollDInputDevicesAddr + 0x5A + 1);
+
+	const DWORD HandleDInputAddr = PollDInputDevicesAddr + 0x159;
+
+	int32_t jmpAddress = 0;
+	memcpy( &jmpAddress, (void*)(HandleDInputAddr + 1), sizeof(jmpAddress) );
+
+	orgProcessDInputData = decltype(orgProcessDInputData)(jmpAddress + HandleDInputAddr + 5);
+	WriteCalltoMemory((BYTE*)HandleDInputAddr, ProcessDInputData_Hook);
+
+	// Default to centered POV hats, as the game will never write to joy state if controller is not there - but it will read from it
+	std::fill(std::begin(dinputJoyState->rgdwPOV), std::end(dinputJoyState->rgdwPOV), DWORD(-1));
+
+	
+	// If controller is unplugged while playing, clear gamepad input
+	// push eax
+	// call GetDeviceState_Hook
+	// jmp loc_4589CA
+	DWORD GetDeviceState_Addr = PollDInputDevicesAddr + 0x7F;
+
+	BYTE pushEax[] = { 0x50 };
+	UpdateMemoryAddress((void*)GetDeviceState_Addr, pushEax, sizeof(pushEax)); GetDeviceState_Addr += 1;
+	WriteCalltoMemory((BYTE*)GetDeviceState_Addr, GetDeviceState_Hook); GetDeviceState_Addr += 5;
+
+	BYTE jmpLoc[] = { 0xEB, 0x13 };
+	UpdateMemoryAddress((void*)GetDeviceState_Addr, jmpLoc, sizeof(jmpLoc));
+}

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -25,6 +25,7 @@ void UpdateHospitalChase(DWORD *SH2_RoomID);
 void UpdateDynamicDrawDistance(DWORD *SH2_RoomID);
 void UpdateHangOnEsc();
 void UpdateXInputVibration();
+void UpdateDPadMovement();
 void UpdateInfiniteRumble(DWORD *SH2_RoomID);
 void SetWindowHandle(HWND WindowHandle);
 void UnhookWindowHandle();

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -230,6 +230,12 @@ bool APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID lpReserved)
 			UpdateXInputVibration();
 		}
 
+		// DPad movement
+		if (DPadMovementFix)
+		{
+			UpdateDPadMovement();
+		}
+
 		// Loads font texture form tga file
 		if (UseCustomFonts)
 		{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -41,6 +41,7 @@
     <ClCompile Include="Patches\ClosetCutscene.cpp" />
     <ClCompile Include="Patches\Common.cpp" />
     <ClCompile Include="Patches\DisableRedCrossDuringCutscenes.cpp" />
+    <ClCompile Include="Patches\DPadMovement.cpp" />
     <ClCompile Include="Patches\DrawDistance.cpp" />
     <ClCompile Include="Patches\CatacombsMeatRoom.cpp" />
     <ClCompile Include="Patches\EnhancedFlashlight.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -167,6 +167,9 @@
     <ClCompile Include="Patches\Langs.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\DPadMovement.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
This feature was made as kindly requested by Ratiocinator.

This PR adds a `DPadMovementFix` setting. When enabled, following changes are made:

1. DPad buttons mirror analog stick behaviour. This means you are able to walk around and navigate menus using a DPad **and** analog stick.
2. Corrects hotplugging behaviour a bit. Previously, if the game was launched with a controller plugged in, then it was plugged out while performing some action (eg. having a button pressed or analog stick pushed) input would "stick", and would not go away until the game is restarted or controller is plugged back in.

It's been tested and proven to work with and without controllers and on 1.0, 1.1 and DC EXEs.