### PR TITLE
Scale shadow dimensions 50% before blurring

### DIFF
--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -1340,7 +1340,7 @@ HRESULT m_IDirect3DDevice8::DrawSoftShadows()
 {
 	// Variables for soft shadows
 	DWORD SHADOW_OPACITY = 128;
-	int SHADOW_DIVISOR = 2;
+	float SHADOW_DIVISOR = 2;
 	int BLUR_PASSES = 4;
 
 	float screenW = (float)BufferWidth;

--- a/Wrappers/d3d8/IDirect3DDevice8.h
+++ b/Wrappers/d3d8/IDirect3DDevice8.h
@@ -24,6 +24,9 @@ private:
 	IDirect3DTexture8 *pInTexture = NULL;
 	IDirect3DSurface8 *pInSurface = NULL, *pBackBuffer = NULL, *pStencilBuffer = NULL;
 
+	IDirect3DTexture8 *pShrunkTexture = NULL;
+	IDirect3DSurface8 *pShrunkSurface = NULL;
+
 	IDirect3DTexture8 *pOutTexture = NULL;
 	IDirect3DSurface8 *pOutSurface = NULL;
 


### PR DESCRIPTION
75% less pixels to process and allows a similar level of softness with only 4 blur passes vs 16.