### PR TITLE
Make shadows act more like Xbox

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -69,6 +69,7 @@
 	visit(WoodsideRoom208TV, false) \
 	visit(WidescreenFix, true) \
 	visit(WndModeBorder, true) \
+	visit(XboxShadows, false) \
 	visit(XInputVibration, true)
 
 #define VISIT_INT_SETTINGS(visit) \

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -32,6 +32,7 @@
 	visit(HalogenLightFix, true) \
 	visit(HeavensNightWindows, false) \
 	visit(HospitalChaseFix, true) \
+	visit(HospitalRefrigerator, false) \
 	visit(HotelHallwayWindow, false) \
 	visit(HotelWaterFix, true) \
 	visit(ImproveStorageSupport, true) \

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -34,6 +34,7 @@
 	visit(HospitalChaseFix, true) \
 	visit(HospitalRefrigerator, false) \
 	visit(HotelHallwayWindow, false) \
+	visit(HotelStoreroomWindow, false) \
 	visit(HotelWaterFix, true) \
 	visit(ImproveStorageSupport, true) \
 	visit(IncreaseBlood, true) \

--- a/Patches/Common.cpp
+++ b/Patches/Common.cpp
@@ -27,7 +27,7 @@ void *CutscenePosAddr = nullptr;
 BYTE *FlashLightRenderAddr = nullptr;
 void *JamesPosAddr = nullptr;
 void *RoomIDAddr = nullptr;
-BYTE *SpecializedLightAddr = nullptr;
+DWORD *SpecializedLightAddr = nullptr;
 
 void *GetRoomIDPointer()
 {
@@ -176,16 +176,15 @@ BYTE *GetChapterIDPointer()
 	return ChapterIDAddr;
 }
 
-BYTE *GetSpecializedLightPointer()
+DWORD *GetSpecializedLightPointer()
 {
 	if (SpecializedLightAddr)
 	{
 		return SpecializedLightAddr;
 	}
 
-	// Get address for flashlight render
-	constexpr BYTE SpecializedLightSearchBytes[]{ 0x8B, 0x44, 0x24, 0x04, 0x8B, 0x4C, 0x24, 0x08, 0xA3 };
-	SpecializedLightAddr = (BYTE*)ReadSearchedAddresses(0x00445630, 0x004457F0, 0x004457F0, SpecializedLightSearchBytes, sizeof(SpecializedLightSearchBytes), 0x09);
+	constexpr BYTE SpecializedLightSearchBytes[]{ 0x00, 0x00, 0x00, 0x52, 0x6A, 0x22, 0x50, 0x89, 0x1D };
+	SpecializedLightAddr = (DWORD*)ReadSearchedAddresses(0x004FFA1B, 0x004FFD4B, 0x004FF66B, SpecializedLightSearchBytes, sizeof(SpecializedLightSearchBytes), 0x09);
 
 	// Checking address pointer
 	if (!SpecializedLightAddr)

--- a/Patches/Common.cpp
+++ b/Patches/Common.cpp
@@ -185,8 +185,8 @@ DWORD *GetSpecializedLightPointer1()
 	}
 
 	// Get address for flashlight render
-	constexpr BYTE SpecializedLightSearchBytes[]{ 0x00, 0x00, 0x00, 0x52, 0x6A, 0x22, 0x50, 0x89, 0x1D };
-	SpecializedLightAddr1 = (DWORD*)ReadSearchedAddresses(0x004FFA1B, 0x004FFD4B, 0x004FF66B, SpecializedLightSearchBytes, sizeof(SpecializedLightSearchBytes), 0x09);
+	constexpr BYTE SpecializedLightSearchBytes[]{ 0x8B, 0x44, 0x24, 0x04, 0x8B, 0x4C, 0x24, 0x08, 0xA3 };
+	SpecializedLightAddr1 = (DWORD*)ReadSearchedAddresses(0x00445630, 0x004457F0, 0x004457F0, SpecializedLightSearchBytes, sizeof(SpecializedLightSearchBytes), 0x09);
 
 	// Checking address pointer
 	if (!SpecializedLightAddr1)
@@ -206,8 +206,8 @@ DWORD *GetSpecializedLightPointer2()
 	}
 
 	// Get address for flashlight render
-	constexpr BYTE SpecializedLightSearchBytes[]{ 0x8B, 0x44, 0x24, 0x04, 0x8B, 0x4C, 0x24, 0x08, 0xA3 };
-	SpecializedLightAddr2 = (DWORD*)ReadSearchedAddresses(0x00445630, 0x004457F0, 0x004457F0, SpecializedLightSearchBytes, sizeof(SpecializedLightSearchBytes), 0x09);
+	constexpr BYTE SpecializedLightSearchBytes[]{ 0x00, 0x00, 0x00, 0x52, 0x6A, 0x22, 0x50, 0x89, 0x1D };
+	SpecializedLightAddr2 = (DWORD*)ReadSearchedAddresses(0x004FFA1B, 0x004FFD4B, 0x004FF66B, SpecializedLightSearchBytes, sizeof(SpecializedLightSearchBytes), 0x09);
 
 	// Checking address pointer
 	if (!SpecializedLightAddr2)

--- a/Patches/Common.cpp
+++ b/Patches/Common.cpp
@@ -183,7 +183,9 @@ DWORD *GetSpecializedLightPointer()
 		return SpecializedLightAddr;
 	}
 
+	// Get address for flashlight render
 	constexpr BYTE SpecializedLightSearchBytes[]{ 0x00, 0x00, 0x00, 0x52, 0x6A, 0x22, 0x50, 0x89, 0x1D };
+
 	SpecializedLightAddr = (DWORD*)ReadSearchedAddresses(0x004FFA1B, 0x004FFD4B, 0x004FF66B, SpecializedLightSearchBytes, sizeof(SpecializedLightSearchBytes), 0x09);
 
 	// Checking address pointer

--- a/Patches/Common.cpp
+++ b/Patches/Common.cpp
@@ -27,7 +27,8 @@ void *CutscenePosAddr = nullptr;
 BYTE *FlashLightRenderAddr = nullptr;
 void *JamesPosAddr = nullptr;
 void *RoomIDAddr = nullptr;
-DWORD *SpecializedLightAddr = nullptr;
+DWORD *SpecializedLightAddr1 = nullptr;
+DWORD *SpecializedLightAddr2 = nullptr;
 
 void *GetRoomIDPointer()
 {
@@ -176,24 +177,44 @@ BYTE *GetChapterIDPointer()
 	return ChapterIDAddr;
 }
 
-DWORD *GetSpecializedLightPointer()
+DWORD *GetSpecializedLightPointer1()
 {
-	if (SpecializedLightAddr)
+	if (SpecializedLightAddr1)
 	{
-		return SpecializedLightAddr;
+		return SpecializedLightAddr1;
 	}
 
 	// Get address for flashlight render
 	constexpr BYTE SpecializedLightSearchBytes[]{ 0x00, 0x00, 0x00, 0x52, 0x6A, 0x22, 0x50, 0x89, 0x1D };
-
-	SpecializedLightAddr = (DWORD*)ReadSearchedAddresses(0x004FFA1B, 0x004FFD4B, 0x004FF66B, SpecializedLightSearchBytes, sizeof(SpecializedLightSearchBytes), 0x09);
+	SpecializedLightAddr1 = (DWORD*)ReadSearchedAddresses(0x004FFA1B, 0x004FFD4B, 0x004FF66B, SpecializedLightSearchBytes, sizeof(SpecializedLightSearchBytes), 0x09);
 
 	// Checking address pointer
-	if (!SpecializedLightAddr)
+	if (!SpecializedLightAddr1)
 	{
-		Logging::Log() << __FUNCTION__ << " Error: failed to find James Pos function address!";
+		Logging::Log() << __FUNCTION__ << " Error: failed to find James Pos function address 1!";
 		return nullptr;
 	}
 
-	return SpecializedLightAddr;
+	return SpecializedLightAddr1;
+}
+
+DWORD *GetSpecializedLightPointer2()
+{
+	if (SpecializedLightAddr2)
+	{
+		return SpecializedLightAddr2;
+	}
+
+	// Get address for flashlight render
+	constexpr BYTE SpecializedLightSearchBytes[]{ 0x8B, 0x44, 0x24, 0x04, 0x8B, 0x4C, 0x24, 0x08, 0xA3 };
+	SpecializedLightAddr2 = (DWORD*)ReadSearchedAddresses(0x00445630, 0x004457F0, 0x004457F0, SpecializedLightSearchBytes, sizeof(SpecializedLightSearchBytes), 0x09);
+
+	// Checking address pointer
+	if (!SpecializedLightAddr2)
+	{
+		Logging::Log() << __FUNCTION__ << " Error: failed to find James Pos function address 2!";
+		return nullptr;
+	}
+
+	return SpecializedLightAddr2;
 }

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -14,7 +14,7 @@ void *GetCutscenePosPointer();
 BYTE *GetFlashLightRenderPointer();
 void *GetJamesPosPointer();
 void *GetRoomIDPointer();
-BYTE *GetSpecializedLightPointer();
+DWORD *GetSpecializedLightPointer();
 
 // Function forward declaration
 void DisableCDCheck();

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -14,7 +14,8 @@ void *GetCutscenePosPointer();
 BYTE *GetFlashLightRenderPointer();
 void *GetJamesPosPointer();
 void *GetRoomIDPointer();
-DWORD *GetSpecializedLightPointer();
+DWORD *GetSpecializedLightPointer1();
+DWORD *GetSpecializedLightPointer2();
 
 // Function forward declaration
 void DisableCDCheck();
@@ -68,7 +69,8 @@ extern BYTE *FlashLightRenderAddr;
 extern bool IsInBloomEffect;
 extern void *JamesPosAddr;
 extern void *RoomIDAddr;
-extern BYTE *SpecializedLightAddr;
+extern DWORD *SpecializedLightAddr1;
+extern DWORD *SpecializedLightAddr2;
 
 // Run code only once
 #define RUNONCE() \

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -895,6 +895,11 @@ HRESULT m_IDirect3DDevice8::DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT S
 			}
 		}
 
+		if (!silhouetteSurface)
+		{
+			return D3DERR_INVALIDCALL;
+		}
+
 		// Temporarily swap to new color buffer (keep original depth/stencil)
 		ProxyInterface->SetRenderTarget(silhouetteSurface, backbufferDepthStencil);
 		ProxyInterface->Clear(0, NULL, D3DCLEAR_TARGET, D3DCOLOR_ARGB(0, 0, 0, 0), 1.0f, 0);
@@ -925,7 +930,10 @@ HRESULT m_IDirect3DDevice8::DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT S
 		// TODO: Should the soft shadow code do this too?
 		IDirect3DVertexBuffer8 *pStream0;
 		UINT stream0Stride = 0;
-		ProxyInterface->GetStreamSource(0, &pStream0, &stream0Stride);
+		if (SUCCEEDED(ProxyInterface->GetStreamSource(0, &pStream0, &stream0Stride)) && pStream0)
+		{
+			pStream0->Release();
+		}
 
 		// Discard all pixels but James' silhouette
 		DWORD stencilFunc = 0;
@@ -975,6 +983,11 @@ HRESULT m_IDirect3DDevice8::DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT
 			// We're done drawing shadow volumes, toggle flag off
 			shadowVolumeFlag = false;
 
+			if (!silhouetteTexture)
+			{
+				return D3DERR_INVALIDCALL;
+			}
+
 			// Bind our texture of James' silhouette
 			ProxyInterface->SetTexture(0, silhouetteTexture);
 
@@ -1004,7 +1017,10 @@ HRESULT m_IDirect3DDevice8::DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT
 			// TODO: Should the soft shadow code do this too?
 			IDirect3DVertexBuffer8 *pStream0;
 			UINT stream0Stride = 0;
-			ProxyInterface->GetStreamSource(0, &pStream0, &stream0Stride);
+			if (SUCCEEDED(ProxyInterface->GetStreamSource(0, &pStream0, &stream0Stride)) && pStream0)
+			{
+				pStream0->Release();
+			}
 
 			// Backup FVF, use pre-transformed vertices and texture coords
 			DWORD vshader = 0;

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -400,7 +400,7 @@ HRESULT m_IDirect3DDevice8::SetRenderState(D3DRENDERSTATETYPE State, DWORD Value
 		{
 			if (SH2_SpecializedLight1 && *SH2_SpecializedLight1 != 0x01) // In a specialized lighting zone
 			{
-				if (SH2_RoomID && (*SH2_RoomID != 0x20 || *SH2_RoomID != 0x25 || *SH2_RoomID != 0x26)) // Exclude Blue Creek hallways/staircase
+				if (SH2_RoomID && *SH2_RoomID != 0x20 && *SH2_RoomID != 0x25 && *SH2_RoomID != 0x26) // Exclude Blue Creek hallways/staircase
 				{
 					Value = D3DSTENCILOP_ZERO;
 				}

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -98,6 +98,16 @@ HRESULT m_IDirect3DDevice8::Reset(D3DPRESENT_PARAMETERS *pPresentationParameters
 		ReleaseInterface(&pOutTexture);
 	}
 
+	if (silhouetteSurface)
+	{
+		ReleaseInterface(&silhouetteSurface, 2);
+	}
+
+	if (silhouetteTexture)
+	{
+		ReleaseInterface(&silhouetteTexture);
+	}
+
 	// Update presentation parameters
 	UpdatePresentParameter(pPresentationParameters, nullptr, true);
 
@@ -386,7 +396,7 @@ HRESULT m_IDirect3DDevice8::SetRenderState(D3DRENDERSTATETYPE State, DWORD Value
 	// Restores self shadows
 	if (EnableSelfShadows && State == D3DRS_STENCILPASS && Value == D3DSTENCILOP_REPLACE)
 	{
-		if (/*SelfShadowTweaks &&*/ !SH2_SpecializedLight || *SH2_SpecializedLight != 0x01)
+		if (/*SelfShadowTweaks &&*/ SH2_SpecializedLight && *SH2_SpecializedLight != 0x01)
 		{
 			Value = D3DSTENCILOP_ZERO;
 		}

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -883,7 +883,7 @@ HRESULT m_IDirect3DDevice8::DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT S
 		}
 		if (SUCCEEDED(ProxyInterface->GetDepthStencilSurface(&backbufferDepthStencil)) && backbufferDepthStencil)
 		{
-			backbufferDepthStencil->Release(); // Is releasing this necessary when we set it again immediately?
+			backbufferDepthStencil->Release();
 		}
 
 		// Create texture for James' silhouette if it doesn't exist
@@ -1358,7 +1358,7 @@ HRESULT m_IDirect3DDevice8::Clear(DWORD Count, CONST D3DRECT *pRects, DWORD Flag
 	Logging::LogDebug() << __FUNCTION__;
 
 	// Change first Clear call to match Xbox version
-	if (Flags == (D3DCLEAR_TARGET | D3DCLEAR_STENCIL | D3DCLEAR_ZBUFFER) && Color == D3DCOLOR_ARGB(124, 0, 0, 0))
+	if (EnableXboxShadows() && Flags == (D3DCLEAR_TARGET | D3DCLEAR_STENCIL | D3DCLEAR_ZBUFFER) && Color == D3DCOLOR_ARGB(124, 0, 0, 0))
 	{
 		return ProxyInterface->Clear(Count, pRects, Flags, Color, Z, 0);
 	}

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -386,7 +386,7 @@ HRESULT m_IDirect3DDevice8::SetRenderState(D3DRENDERSTATETYPE State, DWORD Value
 	// Restores self shadows
 	if (EnableSelfShadows && State == D3DRS_STENCILPASS && Value == D3DSTENCILOP_REPLACE)
 	{
-		if (/*SelfShadowTweaks &&*/	!SH2_SpecializedLight || *SH2_SpecializedLight != 0x01)
+		if (/*SelfShadowTweaks &&*/ !SH2_SpecializedLight || *SH2_SpecializedLight != 0x01)
 		{
 			Value = D3DSTENCILOP_ZERO;
 		}
@@ -748,9 +748,10 @@ HRESULT m_IDirect3DDevice8::DrawIndexedPrimitive(THIS_ D3DPRIMITIVETYPE Type, UI
 			return hr;
 		}
 	}
-	// Exclude windows in Heaven's Night and Hotel 2F Room Hallway from receiving shadows
+	// Exclude windows in Heaven's Night, Hotel 2F Room Hallway and Hotel Storeroom from receiving shadows
 	else if ((HeavensNightWindows && SH2_RoomID && *SH2_RoomID == 0x0C && Type == D3DPT_TRIANGLESTRIP && MinVertexIndex == 0 && NumVertices == 18 && startIndex == 0 && primCount == 21) ||
-		(HotelHallwayWindow && SH2_RoomID && *SH2_RoomID == 0x9F && Type == D3DPT_TRIANGLESTRIP && MinVertexIndex == 0 && NumVertices == 10 && startIndex == 0 && primCount == 10))
+		(HotelHallwayWindow && SH2_RoomID && *SH2_RoomID == 0x9F && Type == D3DPT_TRIANGLESTRIP && MinVertexIndex == 0 && NumVertices == 10 && startIndex == 0 && primCount == 10) ||
+		(HotelStoreroomWindow && SH2_RoomID && *SH2_RoomID == 0x94 && Type == D3DPT_TRIANGLESTRIP && MinVertexIndex == 0 && NumVertices == 8 && startIndex == 0 && primCount == 8))
 	{
 		DWORD stencilPass, stencilRef = 0;
 

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -383,6 +383,15 @@ HRESULT m_IDirect3DDevice8::SetRenderState(D3DRENDERSTATETYPE State, DWORD Value
 		Value = (Value * 15) / 16;
 	}
 
+	// Restores self shadows
+	if (EnableSelfShadows && State == D3DRS_STENCILPASS && Value == D3DSTENCILOP_REPLACE)
+	{
+		if (/*SelfShadowTweaks &&*/	!SH2_SpecializedLight || *SH2_SpecializedLight != 0x01)
+		{
+			Value = D3DSTENCILOP_ZERO;
+		}
+	}
+
 	// For blur frame flicker fix
 	if (RemoveEffectsFlicker && State == D3DRS_TEXTUREFACTOR)
 	{
@@ -762,7 +771,7 @@ HRESULT m_IDirect3DDevice8::DrawIndexedPrimitive(THIS_ D3DPRIMITIVETYPE Type, UI
 		return hr;
 	}
 	// Exclude refrigerator interior in hospital from receiving shadows
-	else if (/*room ID check here*/ Type == D3DPT_TRIANGLESTRIP && MinVertexIndex == 0 && NumVertices == 1037 && startIndex == 0 && primCount == 1580)
+	else if (HospitalRefrigerator && SH2_RoomID && *SH2_RoomID == 0x53 && Type == D3DPT_TRIANGLESTRIP && MinVertexIndex == 0 && NumVertices == 1037 && startIndex == 0 && primCount == 1580)
 	{
 		DWORD stencilPass = 0;
 

--- a/Wrappers/d3d8/IDirect3DDevice8.h
+++ b/Wrappers/d3d8/IDirect3DDevice8.h
@@ -13,7 +13,8 @@ private:
 	DWORD *SH2_CutsceneID = nullptr;
 	float *SH2_CutsceneCameraPos = nullptr;
 	float *SH2_JamesPos = nullptr;
-	DWORD *SH2_SpecializedLight = nullptr;
+	DWORD *SH2_SpecializedLight1 = nullptr;
+	DWORD *SH2_SpecializedLight2 = nullptr;
 
 	bool SkipSceneFlag = false;
 	DWORD LastCutsceneID = 0;
@@ -79,7 +80,8 @@ public:
 		SH2_CutsceneID = (DWORD*)GetCutsceneIDPointer();
 		SH2_CutsceneCameraPos = (float*)GetCutscenePosPointer();
 		SH2_JamesPos = (float*)GetJamesPosPointer();
-		SH2_SpecializedLight = GetSpecializedLightPointer();
+		SH2_SpecializedLight1 = GetSpecializedLightPointer1();
+		SH2_SpecializedLight2 = GetSpecializedLightPointer2();
 
 		// Create blank texture for white shader fix
 		if (FAILED(ProxyInterface->CreateTexture(1, 1, 1, NULL, D3DFMT_X8R8G8B8, D3DPOOL_MANAGED, &BlankTexture)))
@@ -206,4 +208,5 @@ private:
 	void RestoreState(D3DSTATE *state);
 	template <typename T>
 	void ReleaseInterface(T **ppInterface, UINT ReleaseRefNum = 1);
+	bool EnableXboxShadows();
 };

--- a/Wrappers/d3d8/IDirect3DDevice8.h
+++ b/Wrappers/d3d8/IDirect3DDevice8.h
@@ -13,7 +13,7 @@ private:
 	DWORD *SH2_CutsceneID = nullptr;
 	float *SH2_CutsceneCameraPos = nullptr;
 	float *SH2_JamesPos = nullptr;
-	BYTE *SH2_SpecializedLight = nullptr;
+	DWORD *SH2_SpecializedLight = nullptr;
 
 	bool SkipSceneFlag = false;
 	DWORD LastCutsceneID = 0;

--- a/Wrappers/d3d8/IDirect3DDevice8.h
+++ b/Wrappers/d3d8/IDirect3DDevice8.h
@@ -36,6 +36,11 @@ private:
 
 	IDirect3DTexture8 *BlankTexture = nullptr;
 
+	IDirect3DTexture8 *silhouetteTexture = nullptr;
+	IDirect3DSurface8 *silhouetteSurface = nullptr;
+
+	bool shadowVolumeFlag = false;
+
 	struct CUSTOMVERTEX
 	{
 		FLOAT x, y, z, rhw;


### PR DESCRIPTION
This pull request allows us to easily exclude dynamic objects like James from receiving self shadows.

Basic idea:
1. Draw map and character geometry as usual, anything with `STENCILOP_REPLACE` will draw it's silhouette to the stencil buffer, anything with `STENCILOP_ZERO` with mask it's silhouette from the stencil buffer
2. Draw off the stencil buffer to the color buffer of a new texture, we now have a cutout were we'd like no shadows to appear
3. Clear the stencil buffer, the Xbox version does this but not the PC version, this decouples the visible geometry's render states from affecting the shadow volumes (They should only depend on the Z-Buffer)
4. After drawing all the shadow volumes to the stencil buffer we draw our silhouette texture as a fullscreen quad with alpha testing enabled and z and color writes disabled, this discards any shadow that falls within our silhouette from the stencil buffer
5. Game takes over to draw shadows as normal

A big positive of these changes is we no longer have to go out of our way to detect James because he already has `STENCILOP_REPLACE` set. I'm hopeful other special shadow areas will now Just Work™, but if not, manual exclusion should be simpler due to the properly cleared stencil buffer.

I have adjusted the HeavensNightWindows, HotelHallwayWindow and WoodsideRoom208TV fixes to work with the new method and added in the hospital freezer interior, which just needs a Room ID check for safety.

This probably breaks some of our other fixes and needs testing, apologies in advance @Polymega :stuck_out_tongue:
Likely some D3D reference count issues too, sorry @elishacloud :stuck_out_tongue:

Test dll:
[xbox-shadows.zip](https://github.com/elishacloud/Silent-Hill-2-Enhancements/files/3763726/xbox-shadows.zip)

An Xbox SH2 frame's draw order for reference:
Clear (RT/Stencil/Z) -> Map Geometry (Opaque) -> Dynamic Objects (Opaque) -> Dynamic objects (Transparent) -> Clear (Stencil) -> Shadow Volumes -> Shadows to backbuffer -> Map Geometry (Transparent) -> Fog overlay, lens flares, etc.

And a screenshot with color writes enabled to demonstrate it masking James and the window:
![mask](https://user-images.githubusercontent.com/12547453/67420376-176e1000-f601-11e9-906f-92cc76b01264.png)
