### PR TITLE
Right analog stick support for search camera

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -67,6 +67,7 @@
 	visit(Room312ShadowFix, true) \
 	visit(RowboatAnimationFix, true) \
 	visit(SetBlackPillarBoxes, true) \
+	visit(Southpaw, false) \
 	visit(SteamCrashFix, true) \
 	visit(UnlockJapLang, false) \
 	visit(UseCustomExeStr, true) \

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -90,6 +90,7 @@
 	visit(ResY, 0) \
 	visit(FPSLimit, 30) \
 	visit(IncreaseNoiseEffectRes, 512) \
+	visit(RestoreSearchCamMovement, 1) \
 	visit(SingleCoreAffinity, 1) \
 	visit(SingleCoreAffinityTimer, 5000) \
 	visit(SmallFontWidth, 14) \

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -54,6 +54,9 @@ DPadMovementFix = 1
 ; Allows the same button to be assigned to multiple actions on controllers. (0|1)
 GamepadControlsFix = 1
 
+; Sets right joystick mode for search camera movement on controllers. 1 = XInput (most common), 2 = DirectInput, 3 = DirectInput (less common). (0|1|2|3)
+RestoreSearchCamMovement = 1
+
 ; Restores vibration for controllers. (0|1)
 RestoreVibration = 1
 

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -60,6 +60,9 @@ RestoreSearchCamMovement = 1
 ; Restores vibration for controllers. (0|1)
 RestoreVibration = 1
 
+; Swaps left and right joystick functions. Useful for left handed players. (0|1)
+Southpaw = 0
+
 ; Pad (controller) ID to vibrate. Default pad ID = 0. (0|*)
 PadNumber = 0
 

--- a/Patches/ControllerTweaks.cpp
+++ b/Patches/ControllerTweaks.cpp
@@ -46,20 +46,38 @@ void ProcessDInputData_Hook(GamePadState* state)
 {
 	DIJOYSTATE2& joystickState = *dinputJoyState;
 
-	const DWORD povAngle = joystickState.rgdwPOV[0];
-	const bool centered = LOWORD(povAngle) == 0xFFFF;
-	if ( !centered )
+	if (DPadMovementFix)
 	{
-		// Override analog values with DPad values
-		const double angleRadians = static_cast<double>(povAngle) * M_PI / (180.0 * 100.0);
+		const DWORD povAngle = joystickState.rgdwPOV[0];
+		const bool centered = LOWORD(povAngle) == 0xFFFF;
+		if ( !centered )
+		{
+			// Override analog values with DPad values
+			const double angleRadians = static_cast<double>(povAngle) * M_PI / (180.0 * 100.0);
 
-		joystickState.lX = static_cast<LONG>(std::sin(angleRadians) * 32767.0);
-		joystickState.lY = static_cast<LONG>(std::cos(angleRadians) * -32767.0);
+			joystickState.lX = static_cast<LONG>(std::sin(angleRadians) * 32767.0);
+			joystickState.lY = static_cast<LONG>(std::cos(angleRadians) * -32767.0);
+		}
 	}
 
 	// Populate right stick with data
-	state->m_rightStick.X = joystickState.lRx;
-	state->m_rightStick.Y = joystickState.lRy;
+	switch (RestoreSearchCamMovement)
+	{
+	case 1: // XRot/YRot
+		state->m_rightStick.X = static_cast<short>(joystickState.lRx);
+		state->m_rightStick.Y = static_cast<short>(joystickState.lRy);
+		break;
+	case 2: // Z axis/ZRot
+		state->m_rightStick.X = static_cast<short>(joystickState.lZ);
+		state->m_rightStick.Y = static_cast<short>(joystickState.lRz);
+		break;
+	case 3: // ZRot/Z axis
+		state->m_rightStick.X = static_cast<short>(joystickState.lRz);
+		state->m_rightStick.Y = static_cast<short>(joystickState.lZ);
+		break;
+	default:
+		break;
+	}
 
 	orgProcessDInputData(state);
 }
@@ -115,6 +133,7 @@ void UpdateControllerTweaks()
 
 	const DWORD HandleDInputAddr = PollDInputDevicesAddr + 0x159;
 
+	// Shared
 	int32_t jmpAddress = 0;
 	memcpy( &jmpAddress, (void*)(HandleDInputAddr + 1), sizeof(jmpAddress) );
 
@@ -124,50 +143,54 @@ void UpdateControllerTweaks()
 	// Default to centered POV hats, as the game will never write to joy state if controller is not there - but it will read from it
 	std::fill(std::begin(dinputJoyState->rgdwPOV), std::end(dinputJoyState->rgdwPOV), DWORD(-1));
 
-	
-	// If controller is unplugged while playing, clear gamepad input
-	// push eax
-	// call GetDeviceState_Hook
-	// jmp loc_4589CA
-	DWORD GetDeviceState_Addr = PollDInputDevicesAddr + 0x7F;
+	if (DPadMovementFix)
+	{
+		// If controller is unplugged while playing, clear gamepad input
+		// push eax
+		// call GetDeviceState_Hook
+		// jmp loc_4589CA
+		DWORD GetDeviceState_Addr = PollDInputDevicesAddr + 0x7F;
 
-	BYTE pushEax[] = { 0x50 };
-	UpdateMemoryAddress((void*)GetDeviceState_Addr, pushEax, sizeof(pushEax)); GetDeviceState_Addr += 1;
-	WriteCalltoMemory((BYTE*)GetDeviceState_Addr, GetDeviceState_Hook); GetDeviceState_Addr += 5;
+		BYTE pushEax[] = { 0x50 };
+		UpdateMemoryAddress((void*)GetDeviceState_Addr, pushEax, sizeof(pushEax)); GetDeviceState_Addr += 1;
+		WriteCalltoMemory((BYTE*)GetDeviceState_Addr, GetDeviceState_Hook); GetDeviceState_Addr += 5;
 
-	BYTE jmpLoc[] = { 0xEB, 0x13 };
-	UpdateMemoryAddress((void*)GetDeviceState_Addr, jmpLoc, sizeof(jmpLoc));
+		BYTE jmpLoc[] = { 0xEB, 0x13 };
+		UpdateMemoryAddress((void*)GetDeviceState_Addr, jmpLoc, sizeof(jmpLoc));
+	}
 
+	if (RestoreSearchCamMovement != 0)
+	{
+		// Map right stick to search camera
+		float* rightStickXFloat = *(float**)(0x52E93B+2);
+		float* rightStickYFloat = *(float**)(0x52E9DD+2);
 
-	// Map right stick to search camera
-	float* rightStickXFloat = *(float**)(0x52E93B+2);
-	float* rightStickYFloat = *(float**)(0x52E9DD+2);
+		UpdateMemoryAddress((void*)(0x535CCF + 2), &rightStickXFloat, sizeof(rightStickXFloat) );
+		UpdateMemoryAddress((void*)(0x535D51 + 2), &rightStickXFloat, sizeof(rightStickXFloat) );
 
-	UpdateMemoryAddress((void*)(0x535CCF + 2), &rightStickXFloat, sizeof(rightStickXFloat) );
-	UpdateMemoryAddress((void*)(0x535D51 + 2), &rightStickXFloat, sizeof(rightStickXFloat) );
+		UpdateMemoryAddress((void*)(0x535CE2 + 2), &rightStickYFloat, sizeof(rightStickYFloat) );
+		UpdateMemoryAddress((void*)(0x535D69 + 2), &rightStickYFloat, sizeof(rightStickYFloat) );
 
-	UpdateMemoryAddress((void*)(0x535CE2 + 2), &rightStickYFloat, sizeof(rightStickYFloat) );
-	UpdateMemoryAddress((void*)(0x535D69 + 2), &rightStickYFloat, sizeof(rightStickYFloat) );
+		// Allow for simultaneous walking and moving camera
+		memcpy( &jmpAddress, (void*)(0x54E4B2 + 1), sizeof(jmpAddress) );
+		orgUsingSearchCamera = decltype(orgUsingSearchCamera)(jmpAddress + 0x54E4B2 + 5);
 
-	// Allow for simultaneous walking and moving camera
-	memcpy( &jmpAddress, (void*)(0x54E4B2 + 1), sizeof(jmpAddress) );
-	orgUsingSearchCamera = decltype(orgUsingSearchCamera)(jmpAddress + 0x54E4B2 + 5);
+		// Rotational walk
+		WriteCalltoMemory((BYTE*)0x54E4B2, UsingSearchCamera_SeparateAnalogs);
+		WriteCalltoMemory((BYTE*)0x54F13F, UsingSearchCamera_SeparateAnalogs);
+		WriteCalltoMemory((BYTE*)0x54F209, UsingSearchCamera_SeparateAnalogs);
 
-	// Rotational walk
-	WriteCalltoMemory((BYTE*)0x54E4B2, UsingSearchCamera_SeparateAnalogs);
-	WriteCalltoMemory((BYTE*)0x54F13F, UsingSearchCamera_SeparateAnalogs);
-	WriteCalltoMemory((BYTE*)0x54F209, UsingSearchCamera_SeparateAnalogs);
+		// Directional walk
+		WriteCalltoMemory((BYTE*)0x547FBB, UsingSearchCamera_SeparateAnalogs);
+		WriteCalltoMemory((BYTE*)0x547FFA, UsingSearchCamera_SeparateAnalogs);
+		WriteCalltoMemory((BYTE*)0x54807A, UsingSearchCamera_SeparateAnalogs);
+		WriteCalltoMemory((BYTE*)0x548D70, UsingSearchCamera_SeparateAnalogs);
+		WriteCalltoMemory((BYTE*)0x548DB2, UsingSearchCamera_SeparateAnalogs);
+		WriteCalltoMemory((BYTE*)0x548DF7, UsingSearchCamera_SeparateAnalogs);
+		WriteCalltoMemory((BYTE*)0x548EC6, UsingSearchCamera_SeparateAnalogs);
 
-	// Directional walk
-	WriteCalltoMemory((BYTE*)0x547FBB, UsingSearchCamera_SeparateAnalogs);
-	WriteCalltoMemory((BYTE*)0x547FFA, UsingSearchCamera_SeparateAnalogs);
-	WriteCalltoMemory((BYTE*)0x54807A, UsingSearchCamera_SeparateAnalogs);
-	WriteCalltoMemory((BYTE*)0x548D70, UsingSearchCamera_SeparateAnalogs);
-	WriteCalltoMemory((BYTE*)0x548DB2, UsingSearchCamera_SeparateAnalogs);
-	WriteCalltoMemory((BYTE*)0x548DF7, UsingSearchCamera_SeparateAnalogs);
-	WriteCalltoMemory((BYTE*)0x548EC6, UsingSearchCamera_SeparateAnalogs);
-
-	const BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90 };
-	WriteCalltoMemory((BYTE*)0x535CBD, StartSearchCamera_Hook);
-	UpdateMemoryAddress((BYTE*)(0x535CBD + 5 + 2), nops, sizeof(nops) );
+		const BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90 };
+		WriteCalltoMemory((BYTE*)0x535CBD, StartSearchCamera_Hook);
+		UpdateMemoryAddress((BYTE*)(0x535CBD + 5 + 2), nops, sizeof(nops) );
+	}
 }

--- a/Patches/ControllerTweaks.cpp
+++ b/Patches/ControllerTweaks.cpp
@@ -101,7 +101,7 @@ BOOL StartSearchCamera_Hook()
 	return *moveDirection2 != 0 && *moveDirection2 != 3;
 }
 
-void UpdateDPadMovement()
+void UpdateControllerTweaks()
 {
 	constexpr BYTE PollDInputDevicesSearchBytes[] { 0x33, 0xDB, 0x3B, 0xC3, 0x74, 0x33, 0x8B, 0x08 };
 	const DWORD PollDInputDevicesAddr = SearchAndGetAddresses(0x0045893B, 0x00458B9B, 0x00458B9B, PollDInputDevicesSearchBytes, sizeof(PollDInputDevicesSearchBytes), -0xB);

--- a/Patches/ControllerTweaks.cpp
+++ b/Patches/ControllerTweaks.cpp
@@ -294,5 +294,16 @@ void UpdateControllerTweaks()
 			WriteCalltoMemory(UpdateSearchCameraMatch, StartSearchCamera_Hook);
 			UpdateMemoryAddress(UpdateSearchCameraMatch + 5 + 2, nops, sizeof(nops) );
 		}
+
+		// Southpaw option
+		if (Southpaw)
+		{
+			auto SouthpawPattern = pattern( "C7 05 ? ? ? ? ? ? ? ? C3 90 83 EC 24" ).count(1); // 0x45BCA4
+			if (SouthpawPattern.size() == 1) // Don't treat failure as fatal, since it's a very minor change
+			{
+				const BOOL option = TRUE;
+				UpdateMemoryAddress(SouthpawPattern.get_first( 6 ), &option, sizeof(option));
+			}
+		}
 	}
 }

--- a/Patches/DPadMovement.cpp
+++ b/Patches/DPadMovement.cpp
@@ -83,6 +83,12 @@ void __stdcall GetDeviceState_Hook(IDirectInputDevice8A* device)
 	}
 }
 
+BOOL UsingSearchCamera_SeparateAnalogs()
+{
+	// TODO: Return false only if using gamepad, call stock function otherwise
+	return FALSE;
+}
+
 void UpdateDPadMovement()
 {
 	constexpr BYTE PollDInputDevicesSearchBytes[] { 0x33, 0xDB, 0x3B, 0xC3, 0x74, 0x33, 0x8B, 0x08 };
@@ -130,4 +136,23 @@ void UpdateDPadMovement()
 
 	UpdateMemoryAddress((void*)(0x535CE2 + 2), &rightStickYFloat, sizeof(rightStickYFloat) );
 	UpdateMemoryAddress((void*)(0x535D69 + 2), &rightStickYFloat, sizeof(rightStickYFloat) );
+
+	// Allow for simultaneous walking and moving camera
+
+	// Rotational walk
+	WriteCalltoMemory((BYTE*)0x54E4B2, UsingSearchCamera_SeparateAnalogs);
+	WriteCalltoMemory((BYTE*)0x54F13F, UsingSearchCamera_SeparateAnalogs);
+	WriteCalltoMemory((BYTE*)0x54F209, UsingSearchCamera_SeparateAnalogs);
+
+	// Directional walk
+	WriteCalltoMemory((BYTE*)0x547FBB, UsingSearchCamera_SeparateAnalogs);
+	WriteCalltoMemory((BYTE*)0x547FFA, UsingSearchCamera_SeparateAnalogs);
+	WriteCalltoMemory((BYTE*)0x54807A, UsingSearchCamera_SeparateAnalogs);
+	WriteCalltoMemory((BYTE*)0x548D70, UsingSearchCamera_SeparateAnalogs);
+	WriteCalltoMemory((BYTE*)0x548DB2, UsingSearchCamera_SeparateAnalogs);
+	WriteCalltoMemory((BYTE*)0x548DF7, UsingSearchCamera_SeparateAnalogs);
+	WriteCalltoMemory((BYTE*)0x548EC6, UsingSearchCamera_SeparateAnalogs);
+
+	const BYTE jmp[] = { 0xEB };
+	UpdateMemoryAddress((void*)0x535CC4, jmp, sizeof(jmp));
 }

--- a/Patches/DPadMovement.cpp
+++ b/Patches/DPadMovement.cpp
@@ -119,4 +119,15 @@ void UpdateDPadMovement()
 
 	BYTE jmpLoc[] = { 0xEB, 0x13 };
 	UpdateMemoryAddress((void*)GetDeviceState_Addr, jmpLoc, sizeof(jmpLoc));
+
+
+	// Map right stick to search camera
+	float* rightStickXFloat = *(float**)(0x52E93B+2);
+	float* rightStickYFloat = *(float**)(0x52E9DD+2);
+
+	UpdateMemoryAddress((void*)(0x535CCF + 2), &rightStickXFloat, sizeof(rightStickXFloat) );
+	UpdateMemoryAddress((void*)(0x535D51 + 2), &rightStickXFloat, sizeof(rightStickXFloat) );
+
+	UpdateMemoryAddress((void*)(0x535CE2 + 2), &rightStickYFloat, sizeof(rightStickYFloat) );
+	UpdateMemoryAddress((void*)(0x535D69 + 2), &rightStickYFloat, sizeof(rightStickYFloat) );
 }

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -35,7 +35,7 @@ void UpdateClosetCutscene(DWORD *SH2_CutsceneID, float *SH2_CutsceneCameraPos);
 void UpdateCreatureVehicleSpawn();
 void UpdateCustomExeStr();
 void UpdateCustomFonts();
-void UpdateDPadMovement();
+void UpdateControllerTweaks();
 void UpdateDrawDistance();
 void UpdateDynamicDrawDistance(DWORD *SH2_RoomID);
 void UpdateFogParameters();

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -339,7 +339,7 @@ bool APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID lpReserved)
 		}
 
 		// DPad movement
-		if (DPadMovementFix)
+		if (DPadMovementFix || RestoreSearchCamMovement != 0)
 		{
 			UpdateControllerTweaks();
 		}

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -341,7 +341,7 @@ bool APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID lpReserved)
 		// DPad movement
 		if (DPadMovementFix)
 		{
-			UpdateDPadMovement();
+			UpdateControllerTweaks();
 		}
 
 		// Loads font texture form tga file

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -48,7 +48,7 @@
     <ClCompile Include="Patches\CreatureVehicleSpawn.cpp" />
     <ClCompile Include="Patches\DisableRedCrossDuringCutscenes.cpp" />
     <ClCompile Include="Patches\DisableShadowCutscene.cpp" />
-    <ClCompile Include="Patches\DPadMovement.cpp" />
+    <ClCompile Include="Patches\ControllerTweaks.cpp" />
     <ClCompile Include="Patches\DrawDistance.cpp" />
     <ClCompile Include="Patches\CatacombsMeatRoom.cpp" />
     <ClCompile Include="Patches\EnhancedFlashlight.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -164,9 +164,6 @@
     <ClCompile Include="Patches\Langs.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
-    <ClCompile Include="Patches\DPadMovement.cpp">
-      <Filter>Patches</Filter>
-    </ClCompile>
     <ClCompile Include="Wrappers\d3d8\InterfaceQuery.cpp">
       <Filter>Wrappers\d3d8</Filter>
     </ClCompile>
@@ -222,6 +219,9 @@
       <Filter>Patches</Filter>
     </ClCompile>
     <ClCompile Include="Patches\TreeLighting.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
+    <ClCompile Include="Patches\ControllerTweaks.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
This PR changes the way search camera works with gamepads, restoring right analog stick functionality like on PS2.

Most of the code related to right analog stick was still left in the executable, likely a leftover from PS2. Changes required are:
1) Right stick is now polled from DirectInput.
2) Search camera is now bound to right stick instead of left stick. Thankfully, keyboard controls have been nicely separated so this change doesn't impact KB/M users.

Additionally, "Search camera" toggle now allows the player to walk around when using a gamepad. Keyboard functionality is kept untouched.

`RestoreSearchCamMovement` INI option has been added with multiple options, allowing the player to tailor controls to their specific gamepad - those options mirror the choices XInput Plus gives users when mapping DInput gamepads to XInput:
- 1 - right stick uses X/Y Rotation value (XInput gamepads map to this)
- 2 - right stick uses Z axis/Z Rotation
- 3 - right stick uses Z rotation/Z axis

Who knows, perhaps this very lack of consistency was the reason this feature was cut from PC versions...?

Additionally, a Southpaw option has been added, which swaps all functions of left and right analog sticks. It's a fully polished option present in the game, but it went fully unused, even on PS2.


Comments are suggestions are welcome.