### PR TITLE
Implement FixAdvancedOptions (Fixes #370)

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -30,6 +30,7 @@
 	visit(EnableTexAddrHack, true) \
 	visit(FastTransitions, true) \
 	visit(Fix2D, true) \
+	visit(FixAdvancedOptions, true) \
 	visit(FixAptClockFlashlight, true) \
 	visit(FixAudioThreadDeadlock, true) \
 	visit(FixChainsawSpawn, true) \

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -108,6 +108,9 @@ MainMenuFix = 1
 ; Loads translated main menu text selections for the North American v1.0 and 1.1 EXE. 'start01*.tex' files must be present in 'sh2e\pic\etc\' for this fix to work. (0|1)
 MainMenuTitlePerLang = 1
 
+; Fixes issues in the Advanced Options menu, such as incorrect descriptions appearing when the confirmation prompt shows up. (0|1)
+FixAdvancedOptions = 1
+
 ; Disables the screen position feature in the game's options menu, which is no longer needed for modern displays. (0|1)
 LockScreenPosition = 1
 

--- a/Patches/AdvancedOptionsFix.cpp
+++ b/Patches/AdvancedOptionsFix.cpp
@@ -1,0 +1,184 @@
+/**
+* Copyright (C) 2022 Bruno Russi
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#pragma warning(disable:4740)
+#include <Windows.h>
+#include "Common\Utils.h"
+#include "Common\Settings.h"
+#include "Logging\Logging.h"
+#include "External/Hooking.Patterns/Hooking.Patterns.h"
+#include "External/injector/include/injector/injector.hpp"
+
+static uint32_t* ptrConfirmationPromptState;
+static uint32_t* ptrSelectionIndex;
+
+bool isConfirmationPromptOpen()
+{
+	if (*(uint8_t*)(ptrConfirmationPromptState) == 1)
+		return true;
+	else
+		return false;
+}
+
+int iSelectionIndex()
+{
+	return *(uint8_t*)(ptrSelectionIndex);
+}
+
+__int16(__cdecl* DrawTextOverlay_orig)(); // Originally called sub_480550
+__int16 __declspec(naked) DrawTextOverlay_hook()
+{
+	if (iSelectionIndex() > 2 && iSelectionIndex() < 7) // if index is 3, 4, 5 or 6
+	{
+		// Don't render the 3D effect if the confirmation prompt is open
+		if (isConfirmationPromptOpen())
+			__asm {ret}
+	}
+
+	__asm {jmp DrawTextOverlay_orig}
+}
+
+void PatchAdvancedOptions()
+{
+	Logging::Log() << "Enabling Advanced Options fix...";
+
+	// Get pointer to the state of the confirmation prompt (0 or 1)
+	auto pattern = hook::pattern("A0 ? ? ? ? 84 C0 0F 85 ? ? ? ? E8 ? ? ? ? 8B 0D ? ? ? ? 68");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	ptrConfirmationPromptState = *pattern.count(1).get(0).get<uint32_t*>(1);
+
+	// Get pointer to the selection index (0 to 9)
+	pattern = hook::pattern("66 A1 ? ? ? ? 8B 0D ? ? ? ? 80 3D");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	ptrSelectionIndex = *pattern.count(1).get(0).get<uint32_t*>(2);
+
+	// sub_480550 pointer
+	pattern = hook::pattern("E8 ? ? ? ? E8 ? ? ? ? 8B 15 ? ? ? ? 68 8B 01 00 00 6A 46 68 D1 00 00 00");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	DrawTextOverlay_orig = injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0)).get();
+
+	// General option state (On/Off, etc)
+	pattern = hook::pattern("E8 ? ? ? ? 83 C4 ? A0 ? ? ? ? 84 C0 0F 85 ? ? ? ? 0F BF 05");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	injector::MakeCALL(pattern.count(1).get_first(0), DrawTextOverlay_hook, true);
+
+	// "Noise Effect"
+	pattern = hook::pattern("0F 85 ? ? ? ? E8 ? ? ? ? A1 ? ? ? ? 68 ? ? ? ? 68 ? ? ? ? 6A");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	injector::MakeNOP(pattern.count(1).get_first(0), 6, true); // Option state
+
+	// "High Res. Textures"
+	pattern = hook::pattern("0F 85 ? ? ? ? E8 ? ? ? ? 8B 0D ? ? ? ? 68");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	injector::MakeNOP(pattern.count(1).get_first(0), 6, true); // Nop jne instruction that disables everything
+
+	pattern = hook::pattern("E8 ? ? ? ? E8 ? ? ? ? 8B 15 ? ? ? ? 68 8B 01 00 00 6A 46 68 D1 00 00 00");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	injector::MakeCALL(pattern.count(1).get_first(0), DrawTextOverlay_hook, true); // Option title
+
+	// "Resolution"
+	pattern = hook::pattern("0F 85 ? ? ? ? E8 ? ? ? ? 8B 15");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	injector::MakeNOP(pattern.count(1).get_first(0), 6, true); // Nop jne instruction that disables everything
+
+	pattern = hook::pattern("E8 ? ? ? ? E8 ? ? ? ? A1 ? ? ? ? 68 8B 01 00 00 6A 46 68 CA 00 00 00");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	injector::MakeCALL(pattern.count(1).get_first(0), DrawTextOverlay_hook, true); // Option title
+
+	// "Shadows
+	pattern = hook::pattern("0F 85 ? ? ? ? E8 ? ? ? ? A1 ? ? ? ? 68");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	injector::MakeNOP(pattern.count(1).get_first(0), 6, true); // Nop jne instruction that changes the selection
+
+	pattern = hook::pattern("E8 ? ? ? ? E8 ? ? ? ? 8B 0D ? ? ? ? 68 8B 01 00 00 6A 46 68 CB 00 00 00");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	injector::MakeCALL(pattern.count(1).get_first(0), DrawTextOverlay_hook, true); // Option title
+
+	// "Fog"
+	pattern = hook::pattern("75 ? E8 ? ? ? ? 8B 0D ? ? ? ? 68 04 01 00 00 68 F1 00 00 00 68 B2 00 00 00");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	injector::MakeNOP(pattern.count(1).get_first(0), 2, true); // Nop jne instruction that changes the selection
+
+	pattern = hook::pattern("E8 ? ? ? ? E8 ? ? ? ? 8B 15 ? ? ? ? 68 8B 01 00 00 6A 46 68 CC 00 00 00");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	injector::MakeCALL(pattern.count(1).get_first(0), DrawTextOverlay_hook, true); // Option title
+}

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -72,6 +72,7 @@ void UnhookWindowHandle();
 void ValidateBinary();
 
 void Patch2TBHardDrive();
+void PatchAdvancedOptions();
 void PatchBestGraphics();
 void PatchBinary();
 void PatchCDCheck();
@@ -116,6 +117,7 @@ int GetCurrentMaterialIndex();
 bool IsJames(ModelID id);
 bool IsMariaExcludingEyes(ModelID id);
 bool IsMariaEyes(ModelID id);
+bool isConfirmationPromptOpen();
 
 void OnFileLoadTex(HANDLE hFile, LPCSTR lpFileName);
 void OnFileLoadVid(HANDLE hFile, LPCSTR lpFileName);

--- a/Patches/Resolution.cpp
+++ b/Patches/Resolution.cpp
@@ -134,11 +134,15 @@ void *ResSelectStrRetAddr;
 
 __declspec(naked) void __stdcall ResSelectStrASM()
 {
-	__asm
+	if (FixAdvancedOptions)
 	{
-		call printResStr
-		jmp ResSelectStrRetAddr
+		if (!isConfirmationPromptOpen()) // Needed to fix the advanced menu options. See AdvancedSettingsFix.cpp.
+			__asm {call printResStr}
 	}
+	else
+		__asm {call printResStr}
+
+	__asm {jmp ResSelectStrRetAddr}
 }
 
 void *ResArrowRetAddr;

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -487,6 +487,12 @@ void DelayedStart()
 		SetResolutionPatch();
 	}
 
+	// Fixes issues in the Advanced Options screen
+	if (FixAdvancedOptions)
+	{
+		PatchAdvancedOptions();
+	}
+
 	// Check for update
 	if (AutoUpdateModule)
 	{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -40,6 +40,7 @@
     <ClCompile Include="External\WidescreenFixesPack\source\SilentHill2.WidescreenFix\dllmain.cpp" />
     <ClCompile Include="Logging\Logging.cpp" />
     <ClCompile Include="Patches\2TBHardDriveFix.cpp" />
+    <ClCompile Include="Patches\AdvancedOptionsFix.cpp" />
     <ClCompile Include="Patches\DelayedStart.cpp" />
     <ClCompile Include="Patches\FlashlightClockPush.cpp" />
     <ClCompile Include="Patches\FlashlightFlicker.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
@@ -285,6 +285,9 @@
       <Filter>Patches</Filter>
     </ClCompile>
     <ClCompile Include="Patches\FullscreenVideos.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
+    <ClCompile Include="Patches\AdvancedOptionsFix.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Continuing from #370, almost every problematic option had its own little quirk, but I believe I got it working pretty nicely.

This PR adds the following new option:

> ; Fixes issues in the Advanced Options menu, such as incorrect descriptions appearing when the confirmation prompt shows up. (0|1)
> FixAdvancedOptions = 1

@Polymega, if you want to tweak the name/description, let me know.

Here's a test build:
[d3d8-advOptionsFix-v1.zip](https://github.com/elishacloud/Silent-Hill-2-Enhancements/files/8117974/d3d8-advOptionsFix-v1.zip)

