### PR TITLE
Replace "SH2PC Title" with our window title

### DIFF
--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -109,6 +109,7 @@ void PatchSFXAddr();
 void PatchTexAddr();
 void PatchTownWestGateEvent();
 void PatchTreeLighting();
+void PatchWindowTitle();
 void PatchXInputVibration();
 
 void FindGetModelID();

--- a/Patches/ReplaceWindowTitle.cpp
+++ b/Patches/ReplaceWindowTitle.cpp
@@ -1,0 +1,43 @@
+/**
+* Copyright (C) 2022 Bruno Russi
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+#include "External/Hooking.Patterns/Hooking.Patterns.h"
+#include "External/injector/include/injector/injector.hpp"
+
+HWND __stdcall CreateWindowExA_Hook(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
+{
+	return CreateWindowExA(dwExStyle, lpClassName, "Silent Hill 2: Enhanced Edition" , dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+}
+
+// Replace the vanilla "SH2PC Title" with ours
+void PatchWindowTitle()
+{
+	Logging::Log() << "Patching window title...";
+
+	auto pattern = hook::pattern("FF 15 ? ? ? ? 85 C0 A3 ? ? ? ? 74 ? 8B 0D ? ? ? ? 6A");
+	if (pattern.size() != 1)
+	{
+		Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+		return;
+	}
+
+	injector::MakeNOP(pattern.count(1).get(0).get<uint32_t*>(0), 6, true);
+	injector::MakeCALL(pattern.count(1).get(0).get<uint32_t*>(0), CreateWindowExA_Hook, true);
+}

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -195,6 +195,9 @@ void DelayedStart()
 		}
 	}
 
+	// Replace window title
+	PatchWindowTitle();
+
 	// Hook Direct3D8
 	if (HookDirect3D)
 	{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -61,6 +61,7 @@
     <ClCompile Include="Patches\CatacombsMeatRoom.cpp" />
     <ClCompile Include="Patches\EnhancedFlashlight.cpp" />
     <ClCompile Include="Patches\PauseScreen.cpp" />
+    <ClCompile Include="Patches\ReplaceWindowTitle.cpp" />
     <ClCompile Include="Patches\RotatingMannequinGlitch.cpp" />
     <ClCompile Include="Patches\SaveBGImage.cpp" />
     <ClCompile Include="Patches\SpecialFX.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
@@ -285,6 +285,9 @@
       <Filter>Patches</Filter>
     </ClCompile>
     <ClCompile Include="Patches\FullscreenVideos.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
+    <ClCompile Include="Patches\ReplaceWindowTitle.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
This is just a small change for something that bothers me a bit, so feel free to reject it if you don't think it is necessary.

This PR changes the game's window title form "SH2PC Title" to "Silent Hill 2: Enhanced Edition":

![image](https://user-images.githubusercontent.com/33870163/155203843-46c69aa2-9e25-4090-8073-7de50e244624.png)

"SH2PC Title" _feels_ like a placeholder title that should have been changed before release, but... it never happened, I guess.

``ClassName`` is kept as "SH2PC Class" since something might rely on it (?) and the user never sees that anyway.

@Polymega let me know what you think. Maybe I'm just too nitpicky about minor details like this one 👀 