### PR TITLE
Changes to the Spanish translation for the Launcher

### DIFF
--- a/Common/Unicode.h
+++ b/Common/Unicode.h
@@ -82,3 +82,27 @@ inline DWORD WINAPI GetModuleFileNameA(HMODULE hModule, LPWSTR lpFilename, DWORD
 {
 	return GetModuleFileNameW(hModule, lpFilename, nSize);
 }
+
+inline int CharCount(std::string s, char ch)
+{
+	int count = 0;
+
+	for (int i = 0; (i = s.find(ch, i)) != std::string::npos; i++)
+	{
+		count++;
+	}
+
+	return count;
+}
+
+inline int CharCount(std::wstring s, wchar_t ch)
+{
+	int count = 0;
+
+	for (int i = 0; (i = s.find(ch, i)) != std::wstring::npos; i++)
+	{
+		count++;
+	}
+
+	return count;
+}

--- a/Launcher/Launcher.cpp
+++ b/Launcher/Launcher.cpp
@@ -27,6 +27,7 @@
 #include "Resource.h"
 #include "CWnd.h"
 #include "CConfig.h"
+#include "Common\Unicode.h"
 #include "Common\Settings.h"
 #include "Patches\Patches.h"
 #include "Logging\Logging.h"
@@ -141,8 +142,18 @@ std::wstring GetPrgString(UINT id)
 	};
 
 	auto s = cfg.GetString(str[id].name);
+
+	// Validate language string confirmation
+	if (id == STR_LANG_CONFIRM && (CharCount(s, '%') != 1 || s.find(L"%s") == std::string::npos))
+	{
+		MessageBox(nullptr, L"Error with PRG_Lang_confirm text!", L"Language Error", MB_DEFBUTTON1);
+		return std::wstring(str[id].def);
+	}
+
 	if (s.size())
+	{
 		return s;
+	}
 
 	// return default if no string matches
 	return std::wstring(str[id].def);
@@ -637,7 +648,7 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
 	}
 
 	// create the description field
-	hDesc.CreateWindow(4, r.bottom - 150, r.right - 8, 118, hWnd, hInstance, hFont, hBold);
+	hDesc.CreateWindow(4, r.bottom - 160, r.right - 8, 128, hWnd, hInstance, hFont, hBold);
 
 	// create the bottom buttons
 	int X = 3;

--- a/Launcher/Launcher.vcxproj
+++ b/Launcher/Launcher.vcxproj
@@ -107,6 +107,7 @@ copy /y "$(TargetDir)d3d8.ini" "$(SolutionDir)Common\Settings.ini"</Command>
     <ClInclude Include="..\Common\AutoUpdate.h" />
     <ClInclude Include="..\Common\LoadModules.h" />
     <ClInclude Include="..\Common\Settings.h" />
+    <ClInclude Include="..\Common\Unicode.h" />
     <ClInclude Include="..\Common\Utils.h" />
     <ClInclude Include="..\External\Logging\Logging.h" />
     <ClInclude Include="..\External\MemoryModule\MemoryModule.h" />

--- a/Launcher/Launcher.vcxproj.filters
+++ b/Launcher/Launcher.vcxproj.filters
@@ -59,6 +59,9 @@
     <ClInclude Include="..\External\MemoryModule\MemoryModule.h">
       <Filter>External\MemoryModule</Filter>
     </ClInclude>
+    <ClInclude Include="..\Common\Unicode.h">
+      <Filter>Shared</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\External\xxHash\xxhash.c">

--- a/Launcher/config_es.xml
+++ b/Launcher/config_es.xml
@@ -42,7 +42,7 @@
 
       <Feature name="FullscreenImages">
         <Title>Escalado de imágenes a pantalla completa</Title>
-        <Description>Incorpora la compatibilidad para el Image Enhancement Pack (paquete de mejora de imágenes) del proyecto para que se muestre correctamente. Es necesario activar esta opción si se utiliza el Image Enhancement Pack. El escalado funciona tanto para las imágenes originales a pantalla completa como para las mejoradas.&#x0a;&#x0a;Automático: selecciona automáticamente entre las opciones de ajustar a imagen o llenarla según la relación de aspecto, dando prioridad a la mejor presentación.&#x0a;Ajustar a área de visualización: muestra las imágenes en pantalla completa sin recortarlas. Podrían aparecer bandas o columnas negras según la relación de aspecto.&#x0a;Llenar área de visualización: escala las imágenes a pantalla completa para que llenen el área de visualización, eliminando cualquier banda o columna negra, cubriendo una relación de aspecto máxima de 16:9.</Description>
+        <Description>Incorpora la compatibilidad para el Image Enhancement Pack (paquete de mejora de imágenes) del proyecto para que se muestre correctamente. Es necesario activar esta opción si se utiliza el Image Enhancement Pack. Se aplicará tanto para las imágenes originales a pantalla completa como para las mejoradas.&#x0a;&#x0a;Automático: selecciona automáticamente entre las opciones de ajustar a imagen o llenarla según la relación de aspecto, dando prioridad a la mejor presentación.&#x0a;Ajustar a área de visualización: muestra las imágenes en pantalla completa sin recortarlas. Podrían aparecer bandas o columnas negras.&#x0a;Llenar área de visualización: escala las imágenes a pantalla completa para que llenen el área de visualización, eliminando cualquier banda o columna negra y cubriendo una relación de aspecto máxima de 16:9.</Description>
         <Choices type="list">
           <Value name="Desactivado">0</Value>
           <Value name="Automático" default="true">3</Value>
@@ -73,7 +73,7 @@
 
       <Feature name="ReduceCutsceneFOV">
         <Title>Escalar el campo visual en las cinemáticas</Title>
-        <Description>Las escenas cinemáticas renderizadas en tiempo real serán ampliadas para que coincidan con sus composiciones horizontales en 4:3 mientras se juegue con un formato panorámico. Ocultará los modelos de personajes paralizados que se hayan cargado justo al otro lado del límite de la relación en 4:3 y que estén esperando a entrar en escena.&#x0a;&#x0a;Nota: esta característica solo ampliará la imagen hasta una relación de aspecto de 16:9. No cubrirá una relación más ancha, ya que se recortaría la composición vertical en exceso. Esto quiere decir que las relaciones de aspecto ultrapanorámicas seguirán mostrando anomalías visuales durante las escenas cinemáticas en tiempo real.</Description>
+        <Description>Las escenas cinemáticas renderizadas en tiempo real serán ampliadas para que coincidan con sus composiciones horizontales en 4:3 mientras se juegue con un formato panorámico. Ocultará los modelos de personajes paralizados que se hayan cargado justo al otro lado del límite de la relación en 4:3 y que estén esperando a entrar en escena.&#x0a;&#x0a;Nota: esta característica solo ampliará la imagen hasta una relación de aspecto de 16:9. No cubrirá relaciones más anchas, ya que se recortaría la composición vertical en exceso, es decir, las relaciones de aspecto ultrapanorámicas seguirán mostrando anomalías visuales durante las escenas en tiempo real.</Description>
         <Choices type="check">
           <Value name="Desactivado">0</Value>
           <Value name="Activado" default="true">1</Value>
@@ -1093,6 +1093,8 @@
     <S id="PRG_Launch_exe">sh2pc.exe</S>
     <S id="PRG_Ini_name">d3d8.ini</S>
     <S id="PRG_Ini_error">No se pudo guardar el archivo d3d8.ini.</S>
+    <S id="PRG_Lang_confirm">¿Deseas cambiar de idioma al %s?&#x0a;&#x0a;Do you want to switch to language %s?</S>
+    <S id="PRG_Lang_error">¡Error al reiniciar el iniciador!</S>
     <S id="PRG_Default_confirm">¿Seguro que quieres reiniciar toda la configuración a sus valores predeterminados?</S>
     <S id="PRG_Unsaved"> [sin guardar]</S>
     <S id="PRG_Save_exit">Hay cambios sin guardar. ¿Deseas cambiarlos antes de cerrar?</S>

--- a/Launcher/config_es.xml
+++ b/Launcher/config_es.xml
@@ -1093,7 +1093,7 @@
     <S id="PRG_Launch_exe">sh2pc.exe</S>
     <S id="PRG_Ini_name">d3d8.ini</S>
     <S id="PRG_Ini_error">No se pudo guardar el archivo d3d8.ini.</S>
-    <S id="PRG_Lang_confirm">¿Deseas cambiar de idioma al %s?&#x0a;&#x0a;Do you want to switch to language %s?</S>
+    <S id="PRG_Lang_confirm">¿Deseas cambiar de idioma a: %s?</S>
     <S id="PRG_Lang_error">¡Error al reiniciar el iniciador!</S>
     <S id="PRG_Default_confirm">¿Seguro que quieres reiniciar toda la configuración a sus valores predeterminados?</S>
     <S id="PRG_Unsaved"> [sin guardar]</S>

--- a/Resources/BuildNo.rc
+++ b/Resources/BuildNo.rc
@@ -1,1 +1,1 @@
-#define BUILD_NUMBER 2016 
+#define BUILD_NUMBER 2017 


### PR DESCRIPTION
 - Summarized the two descriptions that were overflowing. The Fullscreen Image Scaling description is currently the longest one used in the Launcher, and while I have summarized it, I would still need to expand the description box one extra line (the largest section is the Misc one, and has space for that extra line). We could also think about this as localization-proofing that particular description, as I'm sure Spanish will not be the only language that needs that much space (not without an important loss of information).
 - Adding translations for the two new strings that have been added. What do you people think about making the language change question a double-language one?