### PR TITLE
Add short delay before fade-in transitions

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -13,6 +13,7 @@
 	visit(ClosetCutsceneFix, true) \
 	visit(CreateLocalFix, true) \
 	visit(d3d8to9, true) \
+    visit(DelayedFadeIn, true) \
 	visit(DisableCutsceneBorders, true) \
 	visit(DisableEnlargedText, true) \
 	visit(DisableGameUX, true) \
@@ -176,6 +177,7 @@
 	visit(CustomFontCol) \
 	visit(CustomFontRow) \
 	visit(CustomModFolder) \
+    visit(DelayedFadeIn) \
 	visit(DisableLogging) \
 	visit(EnableDebugOverlay) \
 	visit(EnableInfoOverlay) \

--- a/Patches/DelayedFadeIn.cpp
+++ b/Patches/DelayedFadeIn.cpp
@@ -1,0 +1,86 @@
+/**
+* Copyright (C) 2022 Murugo
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+
+// Variables for ASM
+DWORD FadeValueAddr = 0;
+float FadeInStartValue = -0.133334f;
+float Zero = 0.0f;
+
+// ASM to initialize the fade value at the start of a fade-in
+__declspec(naked) void __stdcall InitFadeASM()
+{
+    __asm
+    {
+        push eax
+        push ecx
+        mov eax, dword ptr ds : [FadeInStartValue]
+        mov ecx, dword ptr ds : [FadeValueAddr]
+        mov [ecx], eax
+        pop ecx
+        pop eax
+        ret
+    }
+}
+
+// ASM to clamp a negative fade value to zero
+__declspec(naked) void __stdcall ClampFadeASM()
+{
+    __asm
+    {
+        mov eax, dword ptr ds : [FadeValueAddr]
+        fld dword ptr ds : [eax]
+        fsubrp st(1), st(0)
+        fcom dword ptr ds : [Zero]
+        fnstsw ax
+        test ah, 0x41
+        jp ExitAsm
+        fmul dword ptr ds : [Zero]
+
+    ExitAsm:
+        ret
+    }
+}
+
+// Patch fade-in transition to pause for a short duration before fading in the screen.
+// This is intended to hide certain animation artifacts that occur after a room transition.
+void PatchDelayedFadeIn()
+{
+    constexpr BYTE FadeInitValueSearchBytes[]{ 0xB8, 0x13, 0x00, 0x00, 0x00, 0xA3 };
+    DWORD FadeInitValueAddr = SearchAndGetAddresses(0x00478440, 0x004786E0, 0x004788F0, FadeInitValueSearchBytes, sizeof(FadeInitValueSearchBytes), 0x2C);
+    if (!FadeInitValueAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
+        return;
+    }
+
+    constexpr BYTE FadeUpdateSearchBytes[]{ 0x3B, 0xFB, 0x0F, 0x84, 0x92, 0x00, 0x00, 0x00, 0xE8 };
+    DWORD FadeUpdateAddr = SearchAndGetAddresses(0x004790DA, 0x0047937A, 0x0047958A, FadeUpdateSearchBytes, sizeof(FadeUpdateSearchBytes), 0x0D);
+    if (!FadeUpdateAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
+        return;
+    }
+    memcpy(&FadeValueAddr, (void*)(FadeUpdateAddr + 0x02), sizeof(DWORD));
+
+    Logging::Log() << "Patching Delayed Fade-in...";
+    WriteCalltoMemory((BYTE*)FadeInitValueAddr, *InitFadeASM, 0x0A);
+    WriteCalltoMemory((BYTE*)FadeUpdateAddr, *ClampFadeASM, 0x06);
+}

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -118,6 +118,7 @@ HRESULT PatchCustomExeStr();
 void PatchCustomFog();
 void PatchCustomFonts();
 void PatchControllerTweaks();
+void PatchDelayedFadeIn();
 void PatchDrawDistance();
 void PatchFlashlightClockPush();
 void PatchFlashlightFlicker();

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -542,6 +542,12 @@ void DelayedStart()
 		PatchCriware();
 	}
 
+    // Patch delayed fade-in to hide animation artifacts
+    if (DelayedFadeIn)
+    {
+        PatchDelayedFadeIn();
+    }
+
 	// Remove the "Now loading..." message
 	switch (GameVersion)
 	{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -53,6 +53,7 @@
     <ClCompile Include="Include\criware\criware_xaudio2.cpp" />
     <ClCompile Include="Patches\AlternateStomp.cpp" />
     <ClCompile Include="Patches\ChangeClosetSpawn.cpp" />
+    <ClCompile Include="Patches\DelayedFadeIn.cpp" />
     <ClCompile Include="Patches\PatchCriware.cpp" />
     <ClCompile Include="Patches\SaveGameSound.cpp" />
     <ClCompile Include="Logging\Logging.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -356,6 +356,9 @@
     <ClCompile Include="Wrappers\d3d8\Overlay.cpp">
       <Filter>Wrappers\d3d8</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\DelayedFadeIn.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
This PR introduces a hidden bool option `DelayedFadeIn` which adds roughly 2/15 seconds of delay before fading in the screen. This delay helps to hide some distracting animation bugs that occur for a few frames after room transitions. These include [Maria interpolating from her last animation](https://github.com/elishacloud/Silent-Hill-2-Enhancements/issues/28#issuecomment-1324452978) in the previous room into an idle pose, and pools of blood forming quickly on the ground.

This is intended to be a visual change only, i.e. James is still able to move around during this delay. It's possible that there is other game logic that ties player control to whether the screen is fully faded in. Hopefully, the difference is unnoticeable since the delay is only a fraction of a second.

See attached video for a comparison.

https://user-images.githubusercontent.com/49109252/208234775-c99632c7-ab20-4127-86fe-c03425867b4e.mp4