### PR TITLE
Command window mouse fix

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -11,6 +11,7 @@
 	visit(CheckCompatibilityMode, true) \
 	visit(CheckForAdminAccess, true) \
 	visit(ClosetCutsceneFix, true) \
+    visit(CommandWindowMouseFix, true) \
 	visit(CreateLocalFix, true) \
 	visit(d3d8to9, true) \
     visit(DelayedFadeIn, true) \
@@ -179,6 +180,7 @@
 	visit(AnisotropicFiltering) \
 	visit(AntiAliasing) \
 	visit(AudioFadeOutDelayMS) \
+    visit(CommandWindowMouseFix) \
 	visit(CustomFontCharHeight) \
 	visit(CustomFontCharWidth) \
 	visit(CustomFontCol) \

--- a/Patches/CommandWindowMouseFix.cpp
+++ b/Patches/CommandWindowMouseFix.cpp
@@ -1,0 +1,88 @@
+/**
+* Copyright (C) 2023 Murugo
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+#include "Patches\Patches.h"
+
+typedef int32_t(__cdecl* GetMouseHorizontalRawPositionProc)();
+
+GetMouseHorizontalRawPositionProc GetMouseHorizontalRawPosition = nullptr;
+int16_t* SelectionIndex = nullptr;
+void* CommandWindowMouseFixReturnAddr = nullptr;
+
+// Checks the cursor position and updates the selected command in the inventory command window when 3 options are available.
+void Handle3CommandWindow() {
+    if (SelectionIndex == nullptr || GetMouseHorizontalRawPosition == nullptr)
+        return;
+
+    // GetMouseHorizontalRawPosition() returns the horizontal position of the cursor without the
+    // offset added by the WidescreenFixesPack. This allows us to check the absolute position of
+    // the cursor at any aspect ratio.
+    const int32_t MouseX = GetMouseHorizontalRawPosition();
+    if (MouseX <= 355 || MouseX >= 440)
+        return;
+    const int32_t MouseY = GetMouseVerticalPosition();
+    if (MouseY <= 62 || MouseY >= 140)
+        return;
+    if (MouseY < 88)
+        *SelectionIndex = 0;
+    else if (MouseY < 114)
+        *SelectionIndex = 1;
+    else
+        *SelectionIndex = 2;
+}
+
+__declspec(naked) void __stdcall CommandWindowMouseFixASM()
+{
+    __asm
+    {
+        cmp eax, 0x02
+        jnz ExitAsm
+        call Handle3CommandWindow
+        pop edi
+        pop esi
+        pop ebp
+        add esp, 0x18
+        ret
+
+    ExitAsm:
+        jmp CommandWindowMouseFixReturnAddr
+    }
+}
+
+// Patch mouse support for when 3 options are present in the inventory command window.
+void PatchCommandWindowMouseFix()
+{
+    constexpr BYTE CommandMouseInputSearchBytes[]{ 0x5F, 0x5E, 0x5D, 0x83, 0xC4, 0x18, 0xC3, 0x83, 0xF8, 0x01 };
+    DWORD CommandMouseInputAddr = SearchAndGetAddresses(0x00472428, 0x004726C8, 0x004728D8, CommandMouseInputSearchBytes, sizeof(CommandMouseInputSearchBytes), 0x07);
+    if (!CommandMouseInputAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
+        return;
+    }
+    memcpy(&SelectionIndex, (void*)(CommandMouseInputAddr - 0x0B), sizeof(DWORD));
+    CommandWindowMouseFixReturnAddr = (void*)(CommandMouseInputAddr + 0x05);
+
+    DWORD GetMouseXRelativeAddr = 0;
+    memcpy(&GetMouseXRelativeAddr, (void*)(CommandMouseInputAddr - 0x2E), sizeof(DWORD));
+    GetMouseHorizontalRawPosition = (GetMouseHorizontalRawPositionProc)(CommandMouseInputAddr + GetMouseXRelativeAddr - 0x2A);
+
+    Logging::Log() << "Patching Command Window Mouse Fix...";
+    WriteJMPtoMemory((BYTE*)CommandMouseInputAddr, *CommandWindowMouseFixASM, 0x05);
+}

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -164,6 +164,7 @@ void PatchBinary();
 void PatchCDCheck();
 void PatchCatacombsMeatRoom();
 void PatchClosetSpawn();
+void PatchCommandWindowMouseFix();
 void PatchCreatureVehicleSpawn();
 void PatchCriware();
 HRESULT PatchCustomExeStr();

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -579,6 +579,12 @@ void DelayedStart()
         PatchFmvSubtitles();
     }
 
+    // Patch mouse support for the inventory command window
+    if (CommandWindowMouseFix)
+    {
+        PatchCommandWindowMouseFix();
+    }
+
 	// Remove the "Now loading..." message
 	switch (GameVersion)
 	{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -53,6 +53,7 @@
     <ClCompile Include="Include\criware\criware_xaudio2.cpp" />
     <ClCompile Include="Patches\AlternateStomp.cpp" />
     <ClCompile Include="Patches\ChangeClosetSpawn.cpp" />
+    <ClCompile Include="Patches\CommandWindowMouseFix.cpp" />
     <ClCompile Include="Patches\InputTweaks.cpp" />
     <ClCompile Include="Patches\FMVPatches.cpp" />
     <ClCompile Include="Patches\HoldDamage.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -386,6 +386,9 @@
     <ClCompile Include="Patches\FmvSubtitles.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+	<ClCompile Include="Patches\CommandWindowMouseFix.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
This patch fixes two bugs with mouse input in the command window:

1. Allows mouse selection when 3 commands are present, e.g. Use, Combine, Examine (see  #692).
2. Allows keyboard and/or gamepad selection if the mouse is hovering over an option in the command window, similar to other menus in the game.

Right now this is enabled by default using a hidden bool option `CommandWindowMouseFix`, but PLMK if it should be added to the config tool.

https://user-images.githubusercontent.com/49109252/213896128-b77c05c6-43af-4c42-ab69-f64e9d1b80f0.mp4