### PR TITLE
Fix "double" footstep sounds for player characters

### DIFF
--- a/Patches/DoubleFootstepFix.cpp
+++ b/Patches/DoubleFootstepFix.cpp
@@ -1,0 +1,119 @@
+/**
+* Copyright (C) 2023 Murugo
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+
+// Variables for ASM
+DWORD FootstepFlagAddr = 0;
+DWORD JamesFootstepReturnAddr = 0;
+DWORD MariaFootstepReturnAddr = 0;
+
+__declspec(naked) void __stdcall SkipDoubleFootstepASM()
+{
+    __asm
+    {
+        test esi, esi
+        jnz NoDoubleFootstep  // Not footstep 0.
+        mov al, byte ptr ds : [esp + 0x04]
+        test al, al
+        jl NoDoubleFootstep  // Footstep 1 frame number is not set.
+        movsx dx, al
+        cmp cx, dx
+        jl NoDoubleFootstep  // Footstep 1 will not be triggered.
+        // First two footstep flags will trigger this frame, causing a double footstep.
+        mov eax, [FootstepFlagAddr]
+        inc byte ptr ds : [eax]  // Set the footstep 0 flag and don't play the sound. If the double
+                                 // footstep was caused by a large frameskip, the handler will play
+                                 // the second footstep sound on the next frame.
+        mov eax, 1
+        ret
+
+    NoDoubleFootstep:
+        xor eax, eax
+        ret
+    }
+}
+
+__declspec(naked) void __stdcall JamesFootstepASM()
+{
+    __asm
+    {
+        mov al, byte ptr ds : [esp + 0x18]
+        push eax
+        call SkipDoubleFootstepASM
+        add esp, 0x04
+        test eax, eax
+        jz ExitAsm
+        pop esi
+        pop ebp
+        pop ebx
+        add esp, 0x01B0
+        ret
+    ExitASM:
+        movsx eax, byte ptr ds : [esp + esi * 0x08 + 0x11]
+        jmp JamesFootstepReturnAddr
+    }
+}
+
+__declspec(naked) void __stdcall MariaFootstepASM()
+{
+    __asm
+    {
+        mov al, byte ptr ds : [esp + 0x10]
+        push eax
+        call SkipDoubleFootstepASM
+        add esp, 0x04
+        test eax, eax
+        jz ExitAsm
+        pop esi
+        add esp, 0x012C
+        ret
+    ExitASM:
+        movsx eax, byte ptr ds : [esp + esi * 0x08 + 0x09]
+        jmp MariaFootstepReturnAddr
+    }
+}
+
+// Patch footstep handlers for player characters (James and BFaW Maria) to avoid playing a "double" footstep.
+// The extra footstep sound can occur when the player enters a different walk/run animation at the same time
+// the previous animation loops to the starting frame.
+void PatchDoubleFootstepFix()
+{
+    constexpr BYTE JamesFootstepSearchBytes[]{ 0x0F, 0xBE, 0x44, 0xF4, 0x11, 0x48, 0x74, 0x5D };
+    DWORD JamesFootstepInjectAddr = SearchAndGetAddresses(0x0054B330, 0x0054B660, 0x0054AF80, JamesFootstepSearchBytes, sizeof(JamesFootstepSearchBytes), 0x00, __FUNCTION__);
+    if (!JamesFootstepInjectAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
+        return;
+    }
+    constexpr BYTE MariaFootstepSearchBytes[]{ 0x0F, 0xBE, 0x44, 0xF4, 0x09, 0x48, 0x74, 0x5A };
+    DWORD MariaFootstepInjectAddr = SearchAndGetAddresses(0x00549715, 0x00549A45, 0x00549365, MariaFootstepSearchBytes, sizeof(MariaFootstepSearchBytes), 0x00, __FUNCTION__);
+    if (!MariaFootstepInjectAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
+        return;
+    }
+    memcpy(&FootstepFlagAddr, (void*)(JamesFootstepInjectAddr + -0x0C), sizeof(DWORD));
+    JamesFootstepReturnAddr = JamesFootstepInjectAddr + 0x05;
+    MariaFootstepReturnAddr = MariaFootstepInjectAddr + 0x05;
+
+    Logging::Log() << "Patching Double Footstep Fix...";
+    WriteJMPtoMemory((BYTE*)JamesFootstepInjectAddr, *JamesFootstepASM, 0x05);
+    WriteJMPtoMemory((BYTE*)MariaFootstepInjectAddr, *MariaFootstepASM, 0x05);
+}

--- a/Patches/DoubleFootstepFix.cpp
+++ b/Patches/DoubleFootstepFix.cpp
@@ -109,7 +109,7 @@ void PatchDoubleFootstepFix()
         Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
         return;
     }
-    memcpy(&FootstepFlagAddr, (void*)(JamesFootstepInjectAddr + -0x0C), sizeof(DWORD));
+    FootstepFlagAddr = *(DWORD*)(JamesFootstepInjectAddr - 0x0C);
     JamesFootstepReturnAddr = JamesFootstepInjectAddr + 0x05;
     MariaFootstepReturnAddr = MariaFootstepInjectAddr + 0x05;
 

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -172,6 +172,7 @@ void PatchCustomFog();
 void PatchCustomFonts();
 void PatchControllerTweaks();
 void PatchDelayedFadeIn();
+void PatchDoubleFootstepFix();
 void PatchDrawDistance();
 void PatchFlashlightClockPush();
 void PatchFlashlightFlicker();

--- a/Patches/SixtyFPSPatch.cpp
+++ b/Patches/SixtyFPSPatch.cpp
@@ -198,5 +198,7 @@ void PatchSixtyFPS()
 
     PatchHoldDamage();
 
+    PatchDoubleFootstepFix();
+
 	Logging::Log() << "Done applying 60 FPS fixes...";
 }

--- a/Resources/BuildNo.rc
+++ b/Resources/BuildNo.rc
@@ -1,1 +1,1 @@
-#define BUILD_NUMBER 2054 
+#define BUILD_NUMBER 2055 

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -54,6 +54,7 @@
     <ClCompile Include="Patches\AlternateStomp.cpp" />
     <ClCompile Include="Patches\ChangeClosetSpawn.cpp" />
     <ClCompile Include="Patches\CommandWindowMouseFix.cpp" />
+    <ClCompile Include="Patches\DoubleFootstepFix.cpp" />
     <ClCompile Include="Patches\InputTweaks.cpp" />
     <ClCompile Include="Patches\FMVPatches.cpp" />
     <ClCompile Include="Patches\HoldDamage.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -389,6 +389,9 @@
     <ClCompile Include="Patches\CommandWindowMouseFix.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\DoubleFootstepFix.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
This PR adds a patch which removes "double" footstep sounds that can sometimes occur when playing at 60 FPS. This patch is grouped with other high framerate fixes enabled with `SetSixtyFPS`. See https://github.com/elishacloud/Silent-Hill-2-Enhancements/issues/733 for more context.

If timed correctly, it is possible to trigger an additional footstep sound in between left and right footsteps. This happens when the player changes to a different walk/run animation at the point when the previous walk/run animation loops. This is easiest to trigger outdoors -- by pressing D-pad up from an idle position, James/Maria will trigger the sound twice: once when entering a full sprint, and again when slowing down after running out of stamina. Demo:

https://user-images.githubusercontent.com/49109252/225818962-a86846e3-f09d-489d-bbce-3f1fd6f100f6.mp4

Build for testing: [d3d8.dll.zip](https://github.com/elishacloud/Silent-Hill-2-Enhancements/files/10949882/d3d8.dll.zip)