### PR TITLE
Bug fixes for pausing while dying and quick saving

### DIFF
--- a/Patches/Common.cpp
+++ b/Patches/Common.cpp
@@ -99,6 +99,8 @@ float* RPTClosetCutsceneMannequinDespawnAddr = nullptr;
 float* RPTClosetCutsceneBlurredBarsDespawnAddr = nullptr;
 BYTE* InputAssignmentFlagAddr = nullptr;
 float* GlobalFadeHoldValueAddr = nullptr;
+BYTE* PlayerIsDyingAddr = nullptr;
+BYTE* MariaNpcIsDyingAddr = nullptr;
 
 bool ShowDebugOverlay = false;
 bool ShowInfoOverlay = false;
@@ -2139,4 +2141,60 @@ float* GetGlobalFadeHoldValuePointer()
 		(GameVersion == SH2V_DC) ? 0x0094522C : NULL);
 
 	return GlobalFadeHoldValueAddr;
+}
+
+BYTE GetPlayerIsDying()
+{
+    BYTE* pPlayerIsDying = GetPlayerIsDyingPointer();
+
+    return (pPlayerIsDying) ? *pPlayerIsDying : 0;
+}
+
+BYTE* GetPlayerIsDyingPointer()
+{
+    if (PlayerIsDyingAddr)
+    {
+        return PlayerIsDyingAddr;
+    }
+
+    // Get player dying flag addresses
+    constexpr BYTE SearchBytes[]{ 0xEb, 0x03, 0xF6, 0xC4, 0x41, 0x7A, 0x07, 0xC6, 0x05 };
+    void *PlayerIsDying = (void*)ReadSearchedAddresses(0x00535948, 0x00535C78, 0x00535598, SearchBytes, sizeof(SearchBytes), 0x09, __FUNCTION__);
+    if (!PlayerIsDying)
+    {
+        Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+        return nullptr;
+    }
+
+    PlayerIsDyingAddr = (BYTE*)((DWORD)PlayerIsDying);
+
+    return PlayerIsDyingAddr;
+}
+
+BYTE GetMariaNpcIsDying()
+{
+    BYTE* pMariaNpcIsDying = GetMariaNpcIsDyingPointer();
+
+    return (pMariaNpcIsDying) ? *pMariaNpcIsDying : 0;
+}
+
+BYTE* GetMariaNpcIsDyingPointer()
+{
+    if (MariaNpcIsDyingAddr)
+    {
+        return MariaNpcIsDyingAddr;
+    }
+
+    // Get Maria NPC dying flag address
+    constexpr BYTE SearchBytes[]{ 0x0F, 0x86, 0xDC, 0x00, 0x00, 0x00, 0xA1 };
+    void *MariaNpcIsDying = (BYTE*)ReadSearchedAddresses(0x0052D6D3, 0x0052DA03, 0x0052D323, SearchBytes, sizeof(SearchBytes), 0x1D, __FUNCTION__);
+    if (!MariaNpcIsDying)
+    {
+        Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+        return nullptr;
+    }
+
+    MariaNpcIsDyingAddr = (BYTE*)((DWORD)MariaNpcIsDying);
+
+    return MariaNpcIsDyingAddr;
 }

--- a/Patches/GameLoad.cpp
+++ b/Patches/GameLoad.cpp
@@ -212,7 +212,7 @@ __declspec(naked) void __stdcall SaveSubStateASM()
         jmp jmpSaveSubState5Addr
 
     HandleState6:
-        // Write sh2pc.sys and sh2pcsave%02d.dat serially on the same frame
+        // Write sh2pc.sys and sh2pcsave??.dat serially on the same frame
         push 0xC00
         mov eax, dword ptr ds : [SysFileBytesAddr]
         push eax
@@ -368,7 +368,7 @@ void SetGameLoad()
 	UpdateMemoryAddress((void*)&FilesLoadedAddr, (void*)(MariaFunctionAddr + 0x6D), sizeof(DWORD));
 	UpdateMemoryAddress((void*)&CutsceneValueAddr, (void*)(MariaFunctionAddr + 0x53), sizeof(DWORD));
 
-    // Fix for writing sh2pc.sys and sh2pcsave%02d.dat on the same frame
+    // Fix for writing sh2pc.sys and sh2pcsave??.dat on the same frame
     constexpr BYTE SaveSubStateSearchBytes[]{ 0x83, 0xF8, 0x06, 0x77, 0x47, 0xFF };
     DWORD SaveSubStateFuncAddr = SearchAndGetAddresses(0x00453137, 0x00453397, 0x00453397, SaveSubStateSearchBytes, sizeof(SaveSubStateSearchBytes), -0x07, __FUNCTION__);
     if (!SaveSubStateFuncAddr)

--- a/Patches/GameLoad.cpp
+++ b/Patches/GameLoad.cpp
@@ -468,6 +468,13 @@ void RunGameLoad()
 		AllowQuickSaveFlag = FALSE;
 	}
 
+    // Disable quick saving while Maria (NPC) is dying
+    if (GetMariaNpcIsDying() != 0)
+    {
+        DisableQuickSave = true;
+        AllowQuickSaveFlag = FALSE;
+    }
+
 	// Reset quick save when needed
 	if (!DisableQuickSave && !AllowQuickSaveFlag)
 	{

--- a/Patches/InputTweaks.cpp
+++ b/Patches/InputTweaks.cpp
@@ -226,6 +226,12 @@ void InputTweaks::TweakGetDeviceState(LPDIRECTINPUTDEVICE8A ProxyInterface, DWOR
 		if (GameLoadFix && (GetIsWritingQuicksave() == 1 || GetTextAddr() == 1))
 			ControllerData->rgbButtons[KeyBinds.GetPauseButtonBind()] = KEY_CLEAR;
 
+        // Clear the pause button if either the player or Maria (NPC) is dying
+        if (GameLoadFix && (GetPlayerIsDying() != 0 || GetMariaNpcIsDying() != 0))
+        {
+            ControllerData->rgbButtons[KeyBinds.GetPauseButtonBind()] = KEY_CLEAR;
+        }
+
 		// Clear controller data
 		ControllerData = nullptr;
 	}

--- a/Patches/InputTweaks.cpp
+++ b/Patches/InputTweaks.cpp
@@ -305,13 +305,6 @@ void InputTweaks::TweakGetDeviceState(LPDIRECTINPUTDEVICE8A ProxyInterface, DWOR
 			ClearKey(KeyBinds.GetKeyBind(KEY_CANCEL));
 		}
 
-        // Clear the ESC and SKIP key if either the player or Maria (NPC) is dying
-        if (GameLoadFix && (GetPlayerIsDying() != 0 || GetMariaNpcIsDying() != 0))
-        {
-            ClearKey(KeyBinds.GetKeyBind(KEY_SKIP));
-            ClearKey(KeyBinds.GetKeyBind(KEY_CANCEL));
-        }
-
 		// Check if Debug Combo is held down
 		DebugCombo.UpdateHolding();
 
@@ -502,6 +495,13 @@ void InputTweaks::TweakGetDeviceState(LPDIRECTINPUTDEVICE8A ProxyInterface, DWOR
 			ClearKey(KeyBinds.GetKeyBind(KEY_READY_WEAPON));
 			CleanKeys = false;
 		}
+
+        // Clear the ESC and SKIP key if either the player or Maria (NPC) is dying
+        if (GameLoadFix && (GetPlayerIsDying() != 0 || GetMariaNpcIsDying() != 0))
+        {
+            ClearKey(KeyBinds.GetKeyBind(KEY_SKIP));
+            ClearKey(KeyBinds.GetKeyBind(KEY_CANCEL));
+        }
 
 		// Clear Keyboard Data pointer
 		KeyboardData = nullptr;

--- a/Patches/InputTweaks.cpp
+++ b/Patches/InputTweaks.cpp
@@ -299,6 +299,13 @@ void InputTweaks::TweakGetDeviceState(LPDIRECTINPUTDEVICE8A ProxyInterface, DWOR
 			ClearKey(KeyBinds.GetKeyBind(KEY_CANCEL));
 		}
 
+        // Clear the ESC and SKIP key if either the player or Maria (NPC) is dying
+        if (GameLoadFix && (GetPlayerIsDying() != 0 || GetMariaNpcIsDying() != 0))
+        {
+            ClearKey(KeyBinds.GetKeyBind(KEY_SKIP));
+            ClearKey(KeyBinds.GetKeyBind(KEY_CANCEL));
+        }
+
 		// Check if Debug Combo is held down
 		DebugCombo.UpdateHolding();
 

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -66,6 +66,8 @@ int32_t GetTextAddr();
 float GetFrametime();
 BYTE GetInputAssignmentFlag();
 float GetGlobalFadeHoldValue();
+BYTE GetPlayerIsDying();
+BYTE GetMariaNpcIsDying();
 
 // Shared pointer function declaration
 DWORD *GetRoomIDPointer();
@@ -143,6 +145,8 @@ float *GetRPTClosetCutsceneMannequinDespawnPointer();
 float *GetRPTClosetCutsceneBlurredBarsDespawnPointer();
 BYTE* GetInputAssignmentFlagPointer();
 float* GetGlobalFadeHoldValuePointer();
+BYTE* GetPlayerIsDyingPointer();
+BYTE* GetMariaNpcIsDyingPointer();
 
 // Function patch declaration
 void CheckArgumentsForPID();


### PR DESCRIPTION
These fixes address corner cases with quick saving that can cause various issues ranging from visual bugs to softlocks and crashes. Also included is a fix to prevent pausing while dying, since the game already prevents other interactions such as opening the map or inventory screen. All of these are folded into `GameLoadFixes`. Thanks @Polymega for guidance on these changes!

Summary:
- Cancel an in-progress quick save before entering another room.
- Cancel an in-progress quick save when interacting with a save point.
- During a save, write `sh2pc.sys` and `sh2pc??.dat` on the same frame.*
- Prevent opening the pause menu if the player is dying, or if Maria (NPC) is dying.
- Prevent quick saving if Maria (NPC) is dying.
---
\* Typically during a save operation, `sh2pc.sys` and `sh2pc??.dat` are written to disk one frame apart from each other. Due to the first two fixes, it is possible to cancel the quick save on the frame `sh2pc.sys` is updated, but before the save file itself gets written out. Writing the two files at the same time ensures that these do not go out of sync, i.e. avoids "Save game is damaged" in some cases.