### PR TITLE
Fix to stop James from looking at the teddy bear after taking the bent needle

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -123,6 +123,7 @@
 	visit(SpecularFix, true) \
 	visit(SteamCrashFix, true) \
 	visit(SwapLightHeavyAttack, true) \
+    visit(TeddyBearLookFix, true) \
 	visit(UnlockJapLang, true) \
 	visit(UseBestGraphics, true) \
 	visit(UseCustomExeStr, true) \

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -123,7 +123,7 @@
 	visit(SpecularFix, true) \
 	visit(SteamCrashFix, true) \
 	visit(SwapLightHeavyAttack, true) \
-    visit(TeddyBearLookFix, true) \
+	visit(TeddyBearLookFix, true) \
 	visit(UnlockJapLang, true) \
 	visit(UseBestGraphics, true) \
 	visit(UseCustomExeStr, true) \

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -254,6 +254,9 @@ FixFMVSpeed = 1
 ; Correctly syncs Red Pyramid Thing's attack animation to the rest of the cutscene that plays out during the hospital elevator chase sequence.
 HospitalChaseFix = 1
 
+; Prevents James from looking at the teddy bear in the women's locker room on the second floor of Brookhaven Hospital after acquiring the bent needle.
+TeddyBearLookFix = 1
+
 ; Fixes an issue where Lying Figures would exit from underneath vehicles incorrectly.
 FixCreatureVehicleSpawn = 1
 

--- a/Launcher/config.xml
+++ b/Launcher/config.xml
@@ -819,6 +819,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="TeddyBearLookFix">
+        <Title>Fix looking at teddy bear after cutscene</Title>
+        <Description>Prevents James from looking at the teddy bear in the women's locker room on the second floor of Brookhaven Hospital after acquiring the bent needle.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixCreatureVehicleSpawn">
         <Title>Fix Lying Figures exiting from under vehicles</Title>
         <Description>Fixes an issue where Lying Figures would exit from underneath vehicles incorrectly.</Description>

--- a/Launcher/config_br.xml
+++ b/Launcher/config_br.xml
@@ -819,6 +819,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="TeddyBearLookFix">
+        <Title>Fix looking at teddy bear after cutscene</Title>
+        <Description>Prevents James from looking at the teddy bear in the women's locker room on the second floor of Brookhaven Hospital after acquiring the bent needle.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixCreatureVehicleSpawn">
         <Title>Corrigir Lying Figures saindo de baixo dos veículos</Title>
         <Description>Corrige um problema em que as Lying Figures saíam incorretamente de baixo dos veículos.</Description>

--- a/Launcher/config_es.xml
+++ b/Launcher/config_es.xml
@@ -819,6 +819,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="TeddyBearLookFix">
+        <Title>Fix looking at teddy bear after cutscene</Title>
+        <Description>Prevents James from looking at the teddy bear in the women's locker room on the second floor of Brookhaven Hospital after acquiring the bent needle.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixCreatureVehicleSpawn">
         <Title>Corregir la salida de las figuras tendidas desde vehículos</Title>
         <Description>Corrige un problema en el que las figuras tendidas saldrían incorrectamente de debajo de vehículos.</Description>

--- a/Launcher/config_it.xml
+++ b/Launcher/config_it.xml
@@ -819,6 +819,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="TeddyBearLookFix">
+        <Title>Fix looking at teddy bear after cutscene</Title>
+        <Description>Prevents James from looking at the teddy bear in the women's locker room on the second floor of Brookhaven Hospital after acquiring the bent needle.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixCreatureVehicleSpawn">
         <Title>Correggi le Lying Figure che escono da sotto i veicoli</Title>
         <Description>Corregge un bug che causa le l'uscita in modo sbagliato delle Lying Figure.</Description>

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -650,6 +650,7 @@ void PatchSixtyFPS();
 void PatchSpeakerConfigText();
 void PatchSpecificSoundLoopFix();
 void PatchSwapLightHeavyAttack();
+void PatchTeddyBearLookFix();
 void PatchTexAddr();
 void PatchTownWestGateEvent();
 void PatchTreeLighting();

--- a/Patches/TeddyBearLookFix.cpp
+++ b/Patches/TeddyBearLookFix.cpp
@@ -1,0 +1,81 @@
+/**
+* Copyright (C) 2024 Murugo
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Patches.h"
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+
+constexpr int kBentNeedleGameFlag = 0xAA;
+
+// Variables for ASM
+DWORD LookAtReturnAddr1 = 0;
+DWORD LookAtReturnAddr2 = 0;
+BYTE* GameFlagAddr = 0;
+
+bool IsBentNeedleGameFlagSet()
+{
+    return GameFlagAddr[kBentNeedleGameFlag >> 3] & (1 << (kBentNeedleGameFlag & 0x07));
+}
+
+// ASM function that ignores the teddy bear as a game object that James can look at after
+// watching the cutscene.
+__declspec(naked) void __stdcall CheckTeddyBearASM()
+{
+    __asm
+    {
+        mov cx, word ptr ds : [esi + 0x10]
+        cmp cx, 0x0727  // kind == i_bear?
+        jne ExitAsm
+        push eax
+        call IsBentNeedleGameFlagSet
+        test al, al
+        pop eax
+        jz ExitAsm
+        jmp LookAtReturnAddr2
+
+    ExitAsm:
+        movsx eax, cx
+        jmp LookAtReturnAddr1
+    }
+}
+
+// Prevents James from looking at the teddy bear in the women's locker room on the second floor of
+// Brookhaven Hospital after James acquires the bent needle.
+void PatchTeddyBearLookFix()
+{
+    constexpr BYTE LookAtSearchBytes[]{ 0x66, 0x8B, 0x4E, 0x10, 0x0F, 0xBF, 0xC1 };
+    DWORD LookAtInjectAddr = SearchAndGetAddresses(0x00542769, 0x00542A99, 0x005423B9, LookAtSearchBytes, sizeof(LookAtSearchBytes), 0x00, __FUNCTION__);
+    if (!LookAtInjectAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address!";
+        return;
+    }
+    LookAtReturnAddr1 = LookAtInjectAddr + 0x07;
+    LookAtReturnAddr2 = LookAtInjectAddr + 0xA9;
+
+    constexpr BYTE GameFlagSearchBytes[]{ 0x83, 0xFE, 0x01, 0x55, 0x57, 0xBD, 0x00, 0x01, 0x00, 0x00 };
+    GameFlagAddr = (BYTE*)ReadSearchedAddresses(0x0048AA9E, 0x0048AD3E, 0x0048AF4E, GameFlagSearchBytes, sizeof(LookAtSearchBytes), 0x24, __FUNCTION__);
+    if (!LookAtInjectAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address!";
+        return;
+    }
+
+    Logging::Log() << "Patching Teddy Bear Look Fix...";
+    WriteJMPtoMemory((BYTE*)LookAtInjectAddr, *CheckTeddyBearASM, 0x07);
+}

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -646,11 +646,11 @@ void DelayedStart()
 		PatchCustomSFXs();
 	}
 
-    // Patch to prevent James from looking at the teddy bear after picking up the bent needle
-    if (TeddyBearLookFix)
-    {
-        PatchTeddyBearLookFix();
-    }
+	// Patch to prevent James from looking at the teddy bear after picking up the bent needle
+	if (TeddyBearLookFix)
+	{
+		PatchTeddyBearLookFix();
+	}
 
 	// Remove the "Now loading..." message
 	switch (GameVersion)

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -646,6 +646,12 @@ void DelayedStart()
 		PatchCustomSFXs();
 	}
 
+    // Patch to prevent James from looking at the teddy bear after picking up the bent needle
+    if (TeddyBearLookFix)
+    {
+        PatchTeddyBearLookFix();
+    }
+
 	// Remove the "Now loading..." message
 	switch (GameVersion)
 	{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -246,6 +246,7 @@ cmd /q /c "cd /D ""$(ProjectDir)Wrappers\"" &amp;&amp; del build.bat"</Command>
     <ClCompile Include="Patches\Specular.cpp" />
     <ClCompile Include="Patches\SprayEffect.cpp" />
     <ClCompile Include="Patches\SwapLightHeavyAttack.cpp" />
+    <ClCompile Include="Patches\TeddyBearLookFix.cpp" />
     <ClCompile Include="Patches\TexPatch.cpp" />
     <ClCompile Include="Patches\FogAdjustments.cpp" />
     <ClCompile Include="Patches\Fonts.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -419,6 +419,9 @@
     <ClCompile Include="Include\winmm.cpp">
       <Filter>Include</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\TeddyBearLookFix.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
Adding a game fix (`TeddyBearLookFix`) which prevents James from looking at the teddy bear in the hospital 2F women's locker room after picking up the bent needle.

James will look at certain objects in the room that are in his line of sight. Usually, James will stop looking at an object after he picks it up. The teddy bear is a special case since the bear remains on the table after James takes the bent needle. This can confuse players into thinking there is an additional action to take with the bear after watching the cutscene (e.g. #418).

<details><summary>Before -> After</summary>

![i_bear_before](https://github.com/elishacloud/Silent-Hill-2-Enhancements/assets/49109252/161041d6-bb3e-403a-b4ff-03274d36d1ad)

![i_bear_after](https://github.com/elishacloud/Silent-Hill-2-Enhancements/assets/49109252/3589218f-71b5-4701-9510-5962a4f374b9)

</details>
