### PR TITLE
Add fix for the Old Man Coin appearing too early

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -98,6 +98,7 @@
 	visit(MenuSoundsFix, true) \
 	visit(MothDrawOrderFix, true) \
 	visit(NoCDPatch, true) \
+    visit(OldManCoinFix, true) \
 	visit(PauseScreenFix, true) \
 	visit(PistonRoomFix, true) \
 	visit(PreserveSoundsOnLoad, true) \
@@ -236,6 +237,7 @@
 	visit(LockResolution) \
 	visit(NormalFontHeight) \
 	visit(NormalFontWidth) \
+    visit(OldManCoinFix) \
 	visit(QuickSaveCancelFix) \
 	visit(ResX) \
 	visit(ResY) \

--- a/Patches/OldManCoinFix.cpp
+++ b/Patches/OldManCoinFix.cpp
@@ -1,0 +1,40 @@
+/**
+* Copyright (C) 2024 Murugo
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Patches.h"
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+
+// Game flag set after James throws the canned juice down the garbage chute.
+constexpr WORD kCannedJuiceGameFlag = 0x5F;
+
+// Prevents the Old Man Coin from appearing in the garbage chute outside Wood Side Apartments until
+// after James uses the canned juice in the second floor laundry room.
+void PatchOldManCoinFix()
+{
+    constexpr BYTE SearchBytes[]{ 0x1F, 0x07, 0x00, 0x00, 0x76, 0x00, 0x00, 0x00 };
+    DWORD OldManCoinPreFlagAddr = SearchAndGetAddresses(0x008DE900, 0x008E25D0, 0x008E15D0, SearchBytes, sizeof(SearchBytes), 0x06, __FUNCTION__);
+    if (!OldManCoinPreFlagAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address!";
+        return;
+    }
+
+    Logging::Log() << "Patching Old Man Coin Fix...";
+    UpdateMemoryAddress((void*)OldManCoinPreFlagAddr, &kCannedJuiceGameFlag, sizeof(WORD));
+}

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -628,6 +628,7 @@ void PatchMasterVolumeSlider();
 void PatchMemoBrightnes();
 void PatchMenuSounds();
 void PatchMothDrawOrder();
+void PatchOldManCoinFix();
 void PatchPauseScreen();
 void PatchPistonRoom();
 void PatchPreventChainsawSpawn();

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -652,6 +652,12 @@ void DelayedStart()
 		PatchTeddyBearLookFix();
 	}
 
+	// Fix spawn precondition for the Old Man Coin
+	if (OldManCoinFix)
+ 	{
+		PatchOldManCoinFix();
+ 	}
+
 	// Remove the "Now loading..." message
 	switch (GameVersion)
 	{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -209,6 +209,7 @@ cmd /q /c "cd /D ""$(ProjectDir)Wrappers\"" &amp;&amp; del build.bat"</Command>
     <ClCompile Include="Patches\MasterVolume.cpp" />
     <ClCompile Include="Patches\MenuSounds.cpp" />
     <ClCompile Include="Patches\MothDrawOrder.cpp" />
+    <ClCompile Include="Patches\OldManCoinFix.cpp" />
     <ClCompile Include="Patches\PatchCriware.cpp" />
     <ClCompile Include="Patches\PlayWavSound.cpp" />
     <ClCompile Include="Patches\QuickSaveCancelFix.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -422,6 +422,9 @@
     <ClCompile Include="Patches\TeddyBearLookFix.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\OldManCoinFix.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
Adding a patch (`OldManCoinFix`) that prevents the Old Man Coin from appearing in the garbage chute until after James uses the canned juice in the Wood Side Apartments second floor laundry room (#735).

PLMK if you think this should be added as its own game fix in the config tool.