### PR TITLE
Fix alignment issues for the boards that are used in the BFaW tombstone riddle

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -70,6 +70,7 @@
 	visit(ForceTopMost, false) \
 	visit(GameLoadFix, true) \
 	visit(GamepadControlsFix, true) \
+	visit(GravestoneBoardsFix, true) \
 	visit(HalogenLightFix, true) \
 	visit(HookDirect3D, true) \
 	visit(HookDirectInput, true) \

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -302,6 +302,9 @@ FixDrawingTextLine = 1
 ; Center mouse cursor when entering a puzzle.
 CenterPuzzleCursor = 1
 
+; Fix the boards in the BfaW gravestone puzzle being distorted when rotated
+GravestoneBoardsFix = 1
+
 [Game Saves]
 ; Disables free-saving in select rooms that would cause game issues upon file loading back into the rooms. Addresses quick save bugs that could soft lock the game and/or corrupt save files. Note: This feature affects quick save strats for speedrunning.
 GameLoadFix = 1

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -272,6 +272,9 @@ MothDrawOrderFix = 1
 ; Hides a piston behind the wall that would otherwise be seen when Angela opens the door in the Labyrinth during a cutscene.
 PistonRoomFix = 1
 
+; Fix the boards in the BfaW gravestone puzzle from being distorted when rotated.
+GravestoneBoardsFix = 1
+
 ; Changes James' commentary about the back alley Heaven's Night gate at night to properly reflect the gate's status.
 FixTownWestGateEvent = 1
 
@@ -301,9 +304,6 @@ FixDrawingTextLine = 1
 
 ; Center mouse cursor when entering a puzzle.
 CenterPuzzleCursor = 1
-
-; Fix the boards in the BfaW gravestone puzzle being distorted when rotated
-GravestoneBoardsFix = 1
 
 [Game Saves]
 ; Disables free-saving in select rooms that would cause game issues upon file loading back into the rooms. Addresses quick save bugs that could soft lock the game and/or corrupt save files. Note: This feature affects quick save strats for speedrunning.

--- a/Launcher/config.xml
+++ b/Launcher/config.xml
@@ -874,6 +874,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="GravestoneBoardsFix">
+        <Title>Fix distortion in the boards of gravestone puzzle</Title>
+        <Description>Fix the boards in the BfaW gravestone puzzle from being distorted when rotated.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixTownWestGateEvent">
         <Title>Fix town west back alley gate commentary</Title>
         <Description>Changes James' commentary about the back alley Heaven's Night gate at night to properly reflect the gate's status.</Description>

--- a/Launcher/config_br.xml
+++ b/Launcher/config_br.xml
@@ -874,6 +874,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="GravestoneBoardsFix">
+        <Title>Fix distortion in the boards of gravestone puzzle</Title>
+        <Description>Fix the boards in the BfaW gravestone puzzle from being distorted when rotated.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixTownWestGateEvent">
         <Title>Corrigir comentário do portão do beco oeste</Title>
         <Description>Altera o comentário de James sobre o portão da Heaven's Night do beco à noite para refletir adequadamente o status do portão.</Description>

--- a/Launcher/config_es.xml
+++ b/Launcher/config_es.xml
@@ -874,6 +874,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="GravestoneBoardsFix">
+        <Title>Fix distortion in the boards of gravestone puzzle</Title>
+        <Description>Fix the boards in the BfaW gravestone puzzle from being distorted when rotated.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixTownWestGateEvent">
         <Title>Corregir el comentario de la reja del callejón de la parte oeste</Title>
         <Description>Cambia el comentario de James sobre la reja del callejón que da al Heaven's Night por la noche para reflejar correctamente su situación.</Description>

--- a/Launcher/config_it.xml
+++ b/Launcher/config_it.xml
@@ -874,6 +874,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="GravestoneBoardsFix">
+        <Title>Fix distortion in the boards of gravestone puzzle</Title>
+        <Description>Fix the boards in the BfaW gravestone puzzle from being distorted when rotated.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixTownWestGateEvent">
         <Title>Correggi il commento nel vicolo nella parte ovest della città</Title>
         <Description>Cambia il commento di James sul cancello di Heaven's Night nel vicolo per rispecchiare lo stato del cancello.</Description>

--- a/Patches/GravestoneBoardsFix.cpp
+++ b/Patches/GravestoneBoardsFix.cpp
@@ -6,6 +6,7 @@
 static DWORD GravestoneBoardsRetAddr = 0;
 static UIElement* uiElement = nullptr;
 
+#pragma warning(suppress: 4740)
 __declspec(naked) void __stdcall GravestoneBoardsASM()
 {
     __asm {

--- a/Patches/GravestoneBoardsFix.cpp
+++ b/Patches/GravestoneBoardsFix.cpp
@@ -1,0 +1,119 @@
+#include "GravestoneBoardsFix.h"
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+#include "Patches\Patches.h"
+
+static DWORD GravestoneBoardsRetAddr = 0;
+static UIElement* uiElement = nullptr;
+
+__declspec(naked) void __stdcall GravestoneBoardsASM()
+{
+    __asm {
+        mov uiElement, esi
+    }
+
+    // Check we're in the grave room and examining the gravestone
+    if (GetRoomID() == R_MAN_GRAVE_ROOM && IsInFullScreenImageEvent())
+    {
+        // Step 1: Adjust the texture coordinates for each board to more closely match eachother
+
+        // Black board
+        if (uiElement->texCoords.u1 == 0.0f && uiElement->texCoords.v1 == 0.0f &&
+            uiElement->texCoords.u2 != 0.0f && uiElement->texCoords.v2 != 0.0f)
+        {
+            uiElement->texCoords.u1 = 3.0f;
+            uiElement->texCoords.v1 = 1.0f;
+            uiElement->texCoords.u2 = 2548.0f;
+            uiElement->texCoords.v2 = 3320.0f;
+        }
+        // White board
+        else if (uiElement->texCoords.u1 > 2000.0f && uiElement->texCoords.v1 == 0.0f)
+        {
+            uiElement->texCoords.u1 = 2581.0f;
+            uiElement->texCoords.v1 = -5.0f;
+            uiElement->texCoords.u2 = 5126.0f;
+            uiElement->texCoords.v2 = 3320.0f;
+        }
+        // Red board
+        else if (uiElement->texCoords.u1 == 0.0f && uiElement->texCoords.v1 > 3000.0f)
+        {
+            uiElement->texCoords.u1 = 3.0f;
+            uiElement->texCoords.v1 = 3316.0f;
+            uiElement->texCoords.u2 = 2542.0f;
+            uiElement->texCoords.v2 = 6636.0f;
+        }
+
+        // Step 2: Adjust the vertices of the boards for each orientation to properly fill the tombstone cavity
+
+        // Rotated right 90 deg
+        if (uiElement->verts[0].x > 0 && uiElement->verts[0].y < 0 &&
+            uiElement->verts[1].x > 0 && uiElement->verts[1].y > 0 &&
+            uiElement->verts[2].x < 0 && uiElement->verts[2].y < 0 &&
+            uiElement->verts[3].x < 0 && uiElement->verts[3].y > 0)
+        {
+            uiElement->verts[0].x = 1355;
+            uiElement->verts[0].y = -2030;
+            uiElement->verts[1].x = 1355;
+            uiElement->verts[1].y = 1158;
+            uiElement->verts[2].x = -1313;
+            uiElement->verts[2].y = -2030;
+            uiElement->verts[3].x = -1313;
+            uiElement->verts[3].y = 1158;
+        }
+        // Rotated 180 deg
+        else if (uiElement->verts[0].x > 0 && uiElement->verts[0].y > 0 &&
+                 uiElement->verts[1].x < 0 && uiElement->verts[1].y > 0 &&
+                 uiElement->verts[2].x > 0 && uiElement->verts[2].y < 0 &&
+                 uiElement->verts[3].x < 0 && uiElement->verts[3].y < 0)
+        {
+            uiElement->verts[0].x = 1287;
+            uiElement->verts[0].y = 1262;
+            uiElement->verts[1].x = -1267;
+            uiElement->verts[1].y = 1262;
+            uiElement->verts[2].x = 1287;
+            uiElement->verts[2].y = -2066;
+            uiElement->verts[3].x = -1267;
+            uiElement->verts[3].y = -2066;
+        }
+        // Rotated left 90 deg
+        else if (uiElement->verts[0].x < 0 && uiElement->verts[0].y > 0 &&
+                 uiElement->verts[1].x < 0 && uiElement->verts[1].y < 0 &&
+                 uiElement->verts[2].x > 0 && uiElement->verts[2].y > 0 &&
+                 uiElement->verts[3].x > 0 && uiElement->verts[3].y < 0)
+        {
+            uiElement->verts[0].x = -1353;
+            uiElement->verts[0].y = 1176;
+            uiElement->verts[1].x = -1353;
+            uiElement->verts[1].y = -2005;
+            uiElement->verts[2].x = 1315;
+            uiElement->verts[2].y = 1176;
+            uiElement->verts[3].x = 1315;
+            uiElement->verts[3].y = -2005;
+        }
+    }
+
+    __asm {
+        // original instructions
+        mov cx, word ptr ds : [esi + 0x2E]
+        fild dword ptr ds : [0xA33480]
+
+        // return to real function
+        jmp GravestoneBoardsRetAddr
+    }
+}
+
+void PatchGravestoneBoardsFix()
+{
+    constexpr BYTE SearchBytes[]{ 0x90, 0x90, 0x66, 0x8B, 0x4E, 0x2E, 0xDB, 0x05 };
+    DWORD GravestoneBoardsAddr = SearchAndGetAddresses(0x0049EFDE, 0x0049F28E, 0x0049EB4E, SearchBytes, sizeof(SearchBytes), 0x02, __FUNCTION__);
+    if (!GravestoneBoardsAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address!";
+        return;
+    }
+
+    GravestoneBoardsRetAddr = GravestoneBoardsAddr + 0xA;
+
+    Logging::Log() << "Patching Gravestone Boards Fix...";
+    WriteJMPtoMemory((BYTE*)GravestoneBoardsAddr, *GravestoneBoardsASM);
+}

--- a/Patches/GravestoneBoardsFix.h
+++ b/Patches/GravestoneBoardsFix.h
@@ -1,0 +1,57 @@
+#pragma once
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Wrappers\d3d8\DirectX81SDK\include\d3d8.h"
+
+struct StyleBits
+{
+    unsigned short textured        : 1; // 0 = flat shaded, 1 = textured
+    unsigned short unk02           : 1; // affects the vertices, draws larger
+    unsigned short useTexCoords    : 1; // 0 = draw entire texture, 1 = draw portion given by texCoords
+    unsigned short unk08           : 1;
+    unsigned short unk10           : 1;
+    unsigned short useTransparency : 1;
+    unsigned short unk40           : 1;
+    unsigned short fourCorners     : 1; // 0 = quad is specified by top left and bottom right vertices. 1 = vertices are positioned independently.
+    unsigned short unk100          : 1;
+};
+
+struct UIElement
+{
+    IDirect3DBaseTexture8* texture;
+    DWORD dword4; // probably another texture
+    DWORD id;     // avoid trusting this value, the game never uses it and it differs between region/versions
+
+    struct {
+        short x;
+        short y;
+    } verts[4];   // If style.fourCorners == true, only verts[0] and verts[1] are used
+
+    struct {
+        float u1;
+        float v1;
+        float u2;
+        float v2;
+    } texCoords;
+
+    WORD word2C;
+    StyleBits style;
+    WORD word30;
+    WORD word32;
+
+    WORD width;
+    WORD height;
+
+    struct {
+        unsigned char b;
+        unsigned char g;
+        unsigned char r;
+        unsigned char a;
+    } color;
+
+    DWORD reserved3C;
+    DWORD reserved40;
+};
+static_assert(sizeof(UIElement) == 0x44);
+
+void PatchGravestoneBoardsFix();

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -617,6 +617,7 @@ void PatchFogParameters();
 void PatchFullscreenImages();
 void PatchFullscreenVideos();
 void PatchGameLoad();
+void PatchGravestoneBoardsFix();
 void PatchHoldDamage();
 void PatchHoldToStomp();
 void PatchInputTweaks();

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -429,6 +429,12 @@ void DelayedStart()
 		PatchMainMenuTitlePerLang();
 	}
 
+	// Fix the boards in the BfaW gravestone puzzle being distorted when rotated
+	if (GravestoneBoardsFix)
+	{
+		PatchGravestoneBoardsFix();
+	}
+
 	// Reenable game's special FX
 	if (RestoreSpecialFX)
 	{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -209,6 +209,7 @@ cmd /q /c "cd /D ""$(ProjectDir)Wrappers\"" &amp;&amp; del build.bat"</Command>
     <ClCompile Include="Patches\MapTranscription.cpp" />
     <ClCompile Include="Patches\DelayedFadeIn.cpp" />
     <ClCompile Include="Patches\FmvSubtitles.cpp" />
+    <ClCompile Include="Patches\GravestoneBoardsFix.cpp" />
     <ClCompile Include="Patches\MasterVolume.cpp" />
     <ClCompile Include="Patches\MenuSounds.cpp" />
     <ClCompile Include="Patches\MothDrawOrder.cpp" />
@@ -351,6 +352,7 @@ cmd /q /c "cd /D ""$(ProjectDir)Wrappers\"" &amp;&amp; del build.bat"</Command>
     <ClInclude Include="Logging\Logging.h" />
     <ClInclude Include="Patches\FullscreenImages.h" />
     <ClInclude Include="Patches\InputTweaks.h" />
+    <ClInclude Include="Patches\GravestoneBoardsFix.h" />
     <ClInclude Include="Patches\MasterVolume.h" />
     <ClInclude Include="Patches\ModelID.h" />
     <ClInclude Include="Patches\Patches.h" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -434,6 +434,9 @@
     <ClCompile Include="Patches\AtticShadowFixes.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\GravestoneBoardsFix.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">
@@ -654,6 +657,9 @@
     </ClInclude>
     <ClInclude Include="Include\winmm.h">
       <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="Patches\GravestoneBoardsFix.h">
+      <Filter>Patches</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Thanks to @Polymega for providing the color-coded test textures.

Before:
![image](https://github.com/elishacloud/Silent-Hill-2-Enhancements/assets/12547453/650cd193-b781-4f2c-baf9-f165bcfa660c)

After:
![image](https://github.com/elishacloud/Silent-Hill-2-Enhancements/assets/12547453/34f8d8c8-9415-4fa9-924b-500ff9f5f786)

