### PR TITLE
Fix flashlight position during the shower room drain cutscene

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -118,6 +118,7 @@
 	visit(SetBlackPillarBoxes, true) \
 	visit(SetSixtyFPS, true) \
 	visit(SetSwapEffectUpgradeShim, false) \
+	visit(ShowerRoomFlashlightFix, true) \
 	visit(Southpaw, false) \
 	visit(SpecificSoundLoopFix, true) \
 	visit(SpecularFix, true) \
@@ -241,6 +242,7 @@
 	visit(ResX) \
 	visit(ResY) \
 	visit(SetSwapEffectUpgradeShim) \
+	visit(ShowerRoomFlashlightFix) \
 	visit(SmallFontHeight) \
 	visit(SmallFontWidth) \
 	visit(SpaceSize) \

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -647,6 +647,7 @@ void PatchRoomLighting();
 void PatchRowboatAnimation();
 void PatchSaveBGImage();
 void PatchSFXAddr();
+void PatchShowerRoomFlashlightFix();
 void PatchSixtyFPS();
 void PatchSpeakerConfigText();
 void PatchSpeakerConfigLock();

--- a/Patches/ShowerRoomFlashlightFix.cpp
+++ b/Patches/ShowerRoomFlashlightFix.cpp
@@ -1,0 +1,74 @@
+/**
+* Copyright (C) 2024 Murugo
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Patches.h"
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+
+// Variables for ASM
+DWORD PlayerRootAddr = 0;
+DWORD ProgramFlagAddr = 0;
+void *jmpShowerRoomCutsceneReturnAddr = nullptr;
+
+// Determines which cutscene active flag to use to locate the flashlight position. If the current
+// room is R_HSP_SHOWER, uses the player object's status flag, which remains active on the freeze
+// frame when James acquires the elevator key. At this point, the program flag for an active
+// cutscene has already been reset to zero.
+__declspec(naked) void __stdcall CheckShowerRoomCutsceneASM()
+{
+    __asm
+    {
+        mov eax, dword ptr ds : [RoomIDAddr]
+        mov eax, dword ptr ds : [eax]
+        cmp eax, R_HSP_SHOWER
+        jne ExitASM
+        mov eax, dword ptr ds : [PlayerRootAddr]
+        mov eax, dword ptr ds : [eax]
+        test eax, eax
+        jz ExitAsm
+        test word ptr ds : [eax + 0x04], 0x2000
+        jmp jmpShowerRoomCutsceneReturnAddr
+
+    ExitASM:
+        mov eax, dword ptr ds : [ProgramFlagAddr]
+        test byte ptr ds : [eax], 0x40
+        jmp jmpShowerRoomCutsceneReturnAddr
+    }
+}
+
+// During the drain cutscene in the Brookhaven Hospital shower room, prevents the spot light from
+// James's flashlight from suddently shifting on the last frame of the cutscene.
+void PatchShowerRoomFlashlightFix()
+{
+    constexpr BYTE PlayerRootSearchBytes[]{ 0x33, 0xC0, 0x3B, 0xCE, 0x89, 0x44, 0x24, 0x1C };
+    PlayerRootAddr = ReadSearchedAddresses(0x00402D2A, 0x00402D2A, 0x00402D2A, PlayerRootSearchBytes, sizeof(PlayerRootSearchBytes), -0x04, __FUNCTION__);
+
+    constexpr BYTE CheckShowerRoomCutsceneSearchBytes[]{ 0x85, 0xC0, 0x74, 0x27, 0xF6, 0x05 };
+    const DWORD CheckShowerRoomCutsceneAddr = SearchAndGetAddresses(0x0047AC55, 0x0047AEF5, 0x0047B105, CheckShowerRoomCutsceneSearchBytes, sizeof(CheckShowerRoomCutsceneSearchBytes), 0x04, __FUNCTION__);
+
+    if (!PlayerRootAddr || !CheckShowerRoomCutsceneAddr)
+    {
+        Logging::Log() << __FUNCTION__ " Error: failed to find memory address!";
+        return;
+    }
+    ProgramFlagAddr = *(DWORD*)(CheckShowerRoomCutsceneAddr + 0x02);
+    jmpShowerRoomCutsceneReturnAddr = (void*)(CheckShowerRoomCutsceneAddr + 0x07);
+
+    Logging::Log() << "Enabling Shower Room Flashlight Fix...";
+    WriteJMPtoMemory((BYTE*)CheckShowerRoomCutsceneAddr, *CheckShowerRoomCutsceneASM, 7);
+}

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -681,7 +681,13 @@ void DelayedStart()
 	{
 		PatchLowHealthIndicator();
 	}
-
+	
+	// Fix flashlight position during the hospital shower room cutscene
+	if (ShowerRoomFlashlightFix)
+	{
+		PatchShowerRoomFlashlightFix();
+	}
+	
 	// Remove the "Now loading..." and "Press Return to continue." messages
 	switch (GameVersion)
 	{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -248,6 +248,7 @@ cmd /q /c "cd /D ""$(ProjectDir)Wrappers\"" &amp;&amp; del build.bat"</Command>
     <ClCompile Include="Patches\RotatingMannequinGlitch.cpp" />
     <ClCompile Include="Patches\SaveBGImage.cpp" />
     <ClCompile Include="Patches\AtticShadowFixes.cpp" />
+    <ClCompile Include="Patches\ShowerRoomFlashlightFix.cpp" />
     <ClCompile Include="Patches\SixtyFPSPatch.cpp" />
     <ClCompile Include="Patches\SpecialFX.cpp" />
     <ClCompile Include="Patches\Specular.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -437,6 +437,9 @@
     <ClCompile Include="Patches\GravestoneBoardsFix.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\ShowerRoomFlashlightFix.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
Adding a patch that prevents the spotlight from James's flashlight from suddenly shifting on the last frame of the shower room drain cutscene in Brookhaven Hospital (`ShowerRoomFlashlightFix`). Added as a hidden feature since this is a minor fix, but PLMK if this should be its own game fix in the config tool.

https://github.com/elishacloud/Silent-Hill-2-Enhancements/assets/49109252/d634fc2d-7d76-47c3-8c6b-b35fc7b48503

<details><summary>Explanation</summary>

The issue happens on frame 574 of the cutscene (the freeze frame when the "I got an elevator key" text appears). `FUN_0047AC50` retrieves the position of the active spotlight in the scene. At instruction `0047AC59`, there is a check for whether a cutscene is currently playing (`00932194 & 0x40`). If this flag is true, the function copies James's flashlight position from `01FB7D38` ("JamesLightPosOriginal"). Otherwise, it copies from `01FB7D18` ("JamesLightPos").

![sh-store-spotlight](https://github.com/elishacloud/Silent-Hill-2-Enhancements/assets/49109252/e39c1754-c4cb-48c1-9c7c-1003fbb11205)

Since the cutscene effectively ends on frame 574, the cutscene flag resets on this frame, causing the flashlight position to jump ("JamesLightPosOriginal" -> "JamesLightPos").

The patch checks if the current room is the hospital shower room, and if so it checks a different flag for whether a cutscene is active, namely the status of James's object entry (`01FB1005 & 0x20`). This flag remains active on frame 574, since control hasn't yet returned to James until the player dismisses the textbox.

</details>

Test build: [d3d8.dll.zip](https://github.com/elishacloud/Silent-Hill-2-Enhancements/files/14976388/d3d8.dll.zip)

Thanks to Bigmanjapan for researching this bug and providing addresses.