### PR TITLE
Remove delay before LOAD and CONTINUE display on the main menu

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -247,7 +247,6 @@
 	visit(LetterSpacing) \
 	visit(LoadModulesFromMemory) \
 	visit(LockResolution) \
-	visit(MainMenuInstantLoadOptions) \
 	visit(NormalFontHeight) \
 	visit(NormalFontWidth) \
 	visit(OldManCoinFix) \

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -96,6 +96,7 @@
 	visit(LockScreenPosition, true) \
 	visit(LockSpeakerConfig, true) \
 	visit(MainMenuFix, true) \
+	visit(MainMenuInstantLoadOptions, true) \
 	visit(MainMenuTitlePerLang, true) \
 	visit(MemoScreenFix, true) \
 	visit(MenuSoundsFix, true) \
@@ -246,6 +247,7 @@
 	visit(LetterSpacing) \
 	visit(LoadModulesFromMemory) \
 	visit(LockResolution) \
+	visit(MainMenuInstantLoadOptions) \
 	visit(NormalFontHeight) \
 	visit(NormalFontWidth) \
 	visit(OldManCoinFix) \

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -203,6 +203,9 @@ HealthIndicatorOption = 1
 ; Fixes the mouse hitboxes for the game's main menu selections for the North American version 1.1 executable.
 MainMenuFix = 1
 
+; Removes the small delay before the LOAD and CONTINUE selections appear on the main menu.
+MainMenuInstantLoadOptions = 1
+
 ; Fixes numerous text display issues on the game's Options > Advanced Options menu, such as missing and incorrect descriptions when the save confirmation prompt is shown.
 FixAdvancedOptions = 1
 

--- a/Launcher/config.xml
+++ b/Launcher/config.xml
@@ -662,6 +662,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="MainMenuInstantLoadOptions">
+        <Title>Instant load options on main menu</Title>
+        <Description>Removes the small delay before the LOAD and CONTINUE selections appear on the main menu.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixAdvancedOptions">
         <Title>Fix Advanced Options screen</Title>
         <Description>Fixes numerous text display issues on the game's Options > Advanced Options menu, such as missing and incorrect descriptions when the save confirmation prompt is shown.</Description>

--- a/Launcher/config_br.xml
+++ b/Launcher/config_br.xml
@@ -662,6 +662,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="MainMenuInstantLoadOptions">
+        <Title>Instant load options on main menu</Title>
+        <Description>Removes the small delay before the LOAD and CONTINUE selections appear on the main menu.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixAdvancedOptions">
         <Title>Corrigir tela de opções avançadas</Title>
         <Description>Corrige vários problemas de exibição de texto no menu em Opções > Opções Avançadas do jogo, como descrições ausentes e incorretas quando a notificação de confirmação de salvamento é exibida.</Description>

--- a/Launcher/config_es.xml
+++ b/Launcher/config_es.xml
@@ -662,6 +662,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="MainMenuInstantLoadOptions">
+        <Title>Instant load options on main menu</Title>
+        <Description>Removes the small delay before the LOAD and CONTINUE selections appear on the main menu.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixAdvancedOptions">
         <Title>Corregir la pantalla de Opciones avanzadas</Title>
         <Description>Corrige numerosos problemas en la visualización de los textos del menú Opciones > Opciones avanzadas dentro del juego, como las descripciones desaparecidas e incorrectas al mostrar la ventana de confirmación de guardado.</Description>

--- a/Launcher/config_it.xml
+++ b/Launcher/config_it.xml
@@ -662,6 +662,15 @@
         </Choices>
       </Feature>
 
+      <Feature name="MainMenuInstantLoadOptions">
+        <Title>Instant load options on main menu</Title>
+        <Description>Removes the small delay before the LOAD and CONTINUE selections appear on the main menu.</Description>
+        <Choices type="check">
+          <Value name="Disable">0</Value>
+          <Value name="Enable" default="true">1</Value>
+        </Choices>
+      </Feature>
+
       <Feature name="FixAdvancedOptions">
         <Title>Correggi il menu Opzioni Avanzate</Title>
         <Description>Corregge numerosi problemi di disegno del testo nel menu Opzioni > Opzioni Avanzate del gioco, come descrizioni incomplete o errate nel testo di conferma salvataggio del gioco.</Description>

--- a/Patches/MainMenu.cpp
+++ b/Patches/MainMenu.cpp
@@ -231,11 +231,10 @@ void PatchMainMenuTitlePerLang()
 
 namespace
 {
-	constexpr float SysLoadAttemptsMax = 100;
+	constexpr int SysLoadAttemptsMax = 100;
 	int SysLoadAttempts = 0;
 	DWORD SysLoadStateAddr = 0;
 	DWORD MainMenuStateAddr = 0;
-	DWORD* DeltaTimeFuncAddr = nullptr;
 	void* jmpMainMenuSysLoadRetryAddr = 0;
 	void* jmpMainMenuSysLoadReturnAddr = 0;
 }
@@ -303,10 +302,6 @@ void PatchMainMenuInstantLoadOptions()
 	MainMenuStateAddr = *(DWORD*)(SysLoadAddr + 0x02);
 	jmpMainMenuSysLoadRetryAddr = (void*)(SysLoadAddr - 0x05);
 	jmpMainMenuSysLoadReturnAddr = (void*)(SysLoadAddr + 0x06);
-
-	DeltaTimeFuncAddr = GetDeltaTimeFunctionPointer();
-	if (!DeltaTimeFuncAddr)
-		return;
 
 	Logging::Log() << "Enabling Main Menu Instant Load Options...";
 	WriteCalltoMemory((BYTE*)(ResetLoadAttemptsAddr), *MainMenuResetLoadAttemptsASM, 0x05);

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -639,6 +639,7 @@ void PatchInventoryBGMBug();
 void PatchLockScreenPosition();
 void PatchLowHealthIndicator();
 void PatchMainMenu();
+void PatchMainMenuInstantLoadOptions();
 void PatchMainMenuTitlePerLang();
 void PatchMapTranscription();
 void PatchMasterVolumeSlider();

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -722,6 +722,12 @@ void DelayedStart()
 		PatchElevatorCursorColor();
 	}
 
+	// Allow "Load" and "Continue" options on the main menu to appear instantly
+	if (MainMenuInstantLoadOptions)
+	{
+		PatchMainMenuInstantLoadOptions();
+	}
+
 	// Remove the "Now loading..." and "Press Return to continue." messages
 	if (DisableLoadingPressReturnMessages)
 	{


### PR DESCRIPTION
Adding a patch (`MainMenuInstantLoadOptions`) to show LOAD and/or CONTINUE instantly on the main menu if save data already exists.

The game checks whether save data exists by reading sh2pc.sys before the main menu fades in. This happens over multiple frames to prevent the game from hitching on I/O operations, similar to save/load, etc. For me it usually takes between 8 - 14 frames before LOAD and CONTINUE are drawn on the screen.

This patch loops on the function call to `FUN_00452E40` at instruction `00497C7F` to force the sh2pc.sys check and main menu state change to finish in a single frame. In case this check does not complete on time, the patch caps out at 100 attempts before giving up and continuing to the main menu.

Test build:  [d3d8.dll.zip](https://github.com/elishacloud/Silent-Hill-2-Enhancements/files/15211008/d3d8.dll.zip)
