### PR TITLE
Move game load screen flash fix to a separate feature

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -73,6 +73,7 @@
 	visit(FogSpeedFix, true) \
 	visit(ForceTopMost, false) \
 	visit(GameLoadFix, true) \
+	visit(GameLoadFlashFix, true) \
 	visit(GamepadControlsFix, true) \
 	visit(GravestoneBoardsFix, true) \
 	visit(HalogenLightFix, true) \
@@ -241,6 +242,7 @@
 	visit(fog_transparency_layer2) \
 	visit(Fog2DFix) \
 	visit(FullscreenWndMode) \
+	visit(GameLoadFlashFix) \
 	visit(HookDirect3D) \
 	visit(HookDirectInput) \
 	visit(HookDirectSound) \

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -629,6 +629,7 @@ void PatchFogParameters();
 void PatchFullscreenImages();
 void PatchFullscreenVideos();
 void PatchGameLoad();
+void PatchGameLoadFlashFix();
 void PatchHealthIndicatorOption();
 void PatchGravestoneBoardsFix();
 void PatchGreatKnifeBoatSpeed();

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -491,7 +491,7 @@ void DelayedStart()
 		PatchGameLoad();
 	}
 
-    // Fixes momentarily "flash" when save file is loaded
+	// Fixes momentarily "flash" when save file is loaded
 	if (GameLoadFlashFix)
 	{
 		PatchGameLoadFlashFix();

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -491,6 +491,12 @@ void DelayedStart()
 		PatchGameLoad();
 	}
 
+    // Fixes momentarily "flash" when save file is loaded
+	if (GameLoadFlashFix)
+	{
+		PatchGameLoadFlashFix();
+	}
+
 	// Fixes quick save text position and the text fading too quickly bug
 	if (QuickSaveTweaks)
 	{


### PR DESCRIPTION
`GameLoadFix` contains a patch that prevents the screen from flashing when loading a save game (594a1e0). This PR moves the patch to its own feature called `GameLoadFlashFix`. This will allow speedrunners to disable `GameLoadFix` without encountering the screen flash bug.

Once again adding this as a hidden feature. Please let me know if this should be added to the config tool.