### PR TITLE
Fix Wood Side Apartments gate lock appearance and commentary

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -64,7 +64,7 @@
 	visit(FixMemoFading, true) \
 	visit(FixMissingWallChunks, true) \
 	visit(FixSaveBGImage, true) \
-	visit(FixTownWestGateEvent, true) \
+	visit(FixTownGateEvents, true) \
 	visit(FlashlightFlickerFix, true) \
 	visit(FlashlightToggleSFX, true) \
 	visit(FmvSubtitlesNoiseFix, true) \

--- a/Common/Settings.ini
+++ b/Common/Settings.ini
@@ -288,8 +288,8 @@ PistonRoomFix = 1
 ; Fix the boards in the BfaW gravestone puzzle from being distorted when rotated.
 GravestoneBoardsFix = 1
 
-; Changes James' commentary about the back alley Heaven's Night gate at night to properly reflect the gate's status.
-FixTownWestGateEvent = 1
+; Visually removes the lock from the Wood Side Apartments gate once James is inside. Changes James' commentary about the gated entrance at Wood Side apartments and back alley gate at Heaven's Night to properly reflect the gate's status when revisiting them at night.
+FixTownGateEvents = 1
 
 ; Prevents distracting shadow flickering along the patio glass doors while in Hotel Room 312 and restores the chair's shadow during the cutscene that takes place in this room.
 Room312ShadowFix = 1

--- a/Launcher/config.xml
+++ b/Launcher/config.xml
@@ -925,9 +925,9 @@
         </Choices>
       </Feature>
 
-      <Feature name="FixTownWestGateEvent">
-        <Title>Fix town west back alley gate commentary</Title>
-        <Description>Changes James' commentary about the back alley Heaven's Night gate at night to properly reflect the gate's status.</Description>
+      <Feature name="FixTownGateEvents">
+        <Title>Fix town gates commentary and appearance</Title>
+        <Description>Visually removes the lock from the Wood Side Apartments gate once James is inside. Changes James' commentary about the gated entrance at Wood Side apartments and back alley gate at Heaven's Night to properly reflect the gate's status when revisiting them at night.</Description>
         <Choices type="check">
           <Value name="Disable">0</Value>
           <Value name="Enable" default="true">1</Value>

--- a/Launcher/config_br.xml
+++ b/Launcher/config_br.xml
@@ -925,7 +925,7 @@
         </Choices>
       </Feature>
 
-      <Feature name="FixTownWestGateEvent">
+      <Feature name="FixTownGateEvents">
         <Title>Corrigir comentário do portão do beco oeste</Title>
         <Description>Altera o comentário de James sobre o portão da Heaven's Night do beco à noite para refletir adequadamente o status do portão.</Description>
         <Choices type="check">

--- a/Launcher/config_es.xml
+++ b/Launcher/config_es.xml
@@ -925,7 +925,7 @@
         </Choices>
       </Feature>
 
-      <Feature name="FixTownWestGateEvent">
+      <Feature name="FixTownGateEvents">
         <Title>Corregir el comentario de la reja del callejón de la parte oeste</Title>
         <Description>Cambia el comentario de James sobre la reja del callejón que da al Heaven's Night por la noche para reflejar correctamente su situación.</Description>
         <Choices type="check">

--- a/Launcher/config_it.xml
+++ b/Launcher/config_it.xml
@@ -925,7 +925,7 @@
         </Choices>
       </Feature>
 
-      <Feature name="FixTownWestGateEvent">
+      <Feature name="FixTownGateEvents">
         <Title>Correggi il commento nel vicolo nella parte ovest della città</Title>
         <Description>Cambia il commento di James sul cancello di Heaven's Night nel vicolo per rispecchiare lo stato del cancello.</Description>
         <Choices type="check">

--- a/Patches/Langs.cpp
+++ b/Patches/Langs.cpp
@@ -1040,8 +1040,8 @@ constexpr BYTE TownEastGateLockDisplayUpdateVal = 0;
 void PatchTownGateEvents()
 {
 	void* DTownWestGateEventAddr = (void*)SearchAndGetAddresses(0x008DB440, 0x008DF110, 0x008DE110, TownWestGateEventSearchBytes, sizeof(TownWestGateEventSearchBytes), 0x00, __FUNCTION__);
-    void* DTownEastGateEventAddr = (void*)SearchAndGetAddresses(0x008E3F98, 0x008E7C68, 0x008E6C68, TownEastGateEventSearchBytes, sizeof(TownEastGateEventSearchBytes), 0x0C, __FUNCTION__);
-    void* DTownEastGateLockDisplayAddr = (void*)SearchAndGetAddresses(0x00595EA0, 0x00596750, 0x00596070, TownEastGateLockDisplaySearchBytes, sizeof(TownEastGateLockDisplaySearchBytes), 0x20, __FUNCTION__);
+	void* DTownEastGateEventAddr = (void*)SearchAndGetAddresses(0x008E3F98, 0x008E7C68, 0x008E6C68, TownEastGateEventSearchBytes, sizeof(TownEastGateEventSearchBytes), 0x0C, __FUNCTION__);
+	void* DTownEastGateLockDisplayAddr = (void*)SearchAndGetAddresses(0x00595EA0, 0x00596750, 0x00596070, TownEastGateLockDisplaySearchBytes, sizeof(TownEastGateLockDisplaySearchBytes), 0x20, __FUNCTION__);
 
 	// Checking address pointer
 	if (!DTownWestGateEventAddr || !DTownEastGateEventAddr || !DTownEastGateLockDisplayAddr)
@@ -1050,9 +1050,8 @@ void PatchTownGateEvents()
 		return;
 	}
 
-    // TODO: Remove "West" from feature and function name(s)
-	Logging::Log() << "Enabling Town West Gate Event Fix...";
+	Logging::Log() << "Enabling Town Gate Event Fixes...";
 	UpdateMemoryAddress(DTownWestGateEventAddr, (void*)TownWestGateEventUpdateVal, sizeof(TownWestGateEventUpdateVal));
-    UpdateMemoryAddress(DTownEastGateEventAddr, &TownEastGateEventUpdateVal, sizeof(DWORD));
-    UpdateMemoryAddress(DTownEastGateLockDisplayAddr, &TownEastGateLockDisplayUpdateVal, sizeof(BYTE));
+	UpdateMemoryAddress(DTownEastGateEventAddr, &TownEastGateEventUpdateVal, sizeof(DWORD));
+	UpdateMemoryAddress(DTownEastGateLockDisplayAddr, &TownEastGateLockDisplayUpdateVal, sizeof(BYTE));
 }

--- a/Patches/Langs.cpp
+++ b/Patches/Langs.cpp
@@ -1031,17 +1031,28 @@ char* getHealthIndicatorDescriptionStr()
 constexpr BYTE TownWestGateEventSearchBytes[] = { 0x00, 0x00, 0x00, 0x90, 0x00, 0xC0, 0x3F, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x60, 0x6E, 0x20 };
 constexpr BYTE TownWestGateEventUpdateVal[] = { 0x00, 0x00, 0x00, 0x60, 0x00, 0x80, 0x13, 0x00 };
 
-void PatchTownWestGateEvent()
+constexpr BYTE TownEastGateEventSearchBytes[] = { 0x00, 0x00, 0xFB, 0x80, 0x00, 0x20, 0xA6, 0x20, 0x00, 0x00, 0x00 };
+constexpr DWORD TownEastGateEventUpdateVal = 0;
+
+constexpr BYTE TownEastGateLockDisplaySearchBytes[] = { 0x83, 0xF8, 0x07, 0x74, 0x2B, 0xA1 };
+constexpr BYTE TownEastGateLockDisplayUpdateVal = 0;
+
+void PatchTownGateEvents()
 {
 	void* DTownWestGateEventAddr = (void*)SearchAndGetAddresses(0x008DB440, 0x008DF110, 0x008DE110, TownWestGateEventSearchBytes, sizeof(TownWestGateEventSearchBytes), 0x00, __FUNCTION__);
+    void* DTownEastGateEventAddr = (void*)SearchAndGetAddresses(0x008E3F98, 0x008E7C68, 0x008E6C68, TownEastGateEventSearchBytes, sizeof(TownEastGateEventSearchBytes), 0x0C, __FUNCTION__);
+    void* DTownEastGateLockDisplayAddr = (void*)SearchAndGetAddresses(0x00595EA0, 0x00596750, 0x00596070, TownEastGateLockDisplaySearchBytes, sizeof(TownEastGateLockDisplaySearchBytes), 0x20, __FUNCTION__);
 
 	// Checking address pointer
-	if (!DTownWestGateEventAddr)
+	if (!DTownWestGateEventAddr || !DTownEastGateEventAddr || !DTownEastGateLockDisplayAddr)
 	{
 		Logging::Log() << __FUNCTION__ << " Error: failed to find memory address!";
 		return;
 	}
 
+    // TODO: Remove "West" from feature and function name(s)
 	Logging::Log() << "Enabling Town West Gate Event Fix...";
 	UpdateMemoryAddress(DTownWestGateEventAddr, (void*)TownWestGateEventUpdateVal, sizeof(TownWestGateEventUpdateVal));
+    UpdateMemoryAddress(DTownEastGateEventAddr, &TownEastGateEventUpdateVal, sizeof(DWORD));
+    UpdateMemoryAddress(DTownEastGateLockDisplayAddr, &TownEastGateLockDisplayUpdateVal, sizeof(BYTE));
 }

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -678,7 +678,7 @@ void PatchSprayEffect();
 void PatchSwapLightHeavyAttack();
 void PatchTeddyBearLookFix();
 void PatchTexAddr();
-void PatchTownWestGateEvent();
+void PatchTownGateEvents();
 void PatchTreeLighting();
 void PatchVHSAudio();
 void PatchWindowIcon();

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -467,10 +467,10 @@ void DelayedStart()
 		PatchHoldToStomp();
 	}
 
-	// Changes the event at the gate near Heaven's Night to that when trying to re-enter the door to Blue Creek Apartments
-	if (FixTownWestGateEvent)
+	// Removes the lock on the Wood Side Apartments gate after entering, and updates commentary on the gates near Heaven's Night and Wood Side Apartments at night
+	if (FixTownGateEvents)
 	{
-		PatchTownWestGateEvent();
+		PatchTownGateEvents();
 	}
 
 	// Disables the screen position feature in the game's options menu, which is no longer needed for modern displays


### PR DESCRIPTION
This PR renames the `FixTownWestGateEvent` feature to `FixTownGateEvents` and includes two new patches to fix some inconsistencies:

- The lock on the Wood Side Apartments gate still appears on the gate even after James uses the key and passes through. **Fix**: The lock will now appear on the ground when James is inside the gate.
- When James returns to the Wood Side Apartments gate at night, he will note that the lock is broken, even though the gate is clearly open with the lock on the ground. **Fix**: James will now remark that there is no reason to go back (similar text used elsewhere in the town). This also removes the broken lock SFX when James interacts with the gate.

<details><summary>Before + After</summary>

![sh2ee-gateevents-0](https://github.com/elishacloud/Silent-Hill-2-Enhancements/assets/49109252/b8adc193-3278-47c9-9b69-6f2a9b5aff3a)
![sh2ee-gateevents-1](https://github.com/elishacloud/Silent-Hill-2-Enhancements/assets/49109252/4ff2a312-3a94-42fb-b96b-9830cf4131e0)

</details>


