### PR TITLE
Adjustments to water appearance and draw order

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -84,7 +84,6 @@
 	visit(HospitalChaseFix, true) \
 	visit(HotelWaterFix, true) \
 	visit(ImproveStorageSupport, true) \
-	visit(ImprovedWaterFX, false) \
 	visit(IncreaseBlood, true) \
 	visit(IncreaseDrawDistance, true) \
 	visit(LegacyFixGPUAntiAliasing, false) \
@@ -254,7 +253,6 @@
 	visit(HookDirectInput) \
 	visit(HookDirectSound) \
 	visit(HookWndProc) \
-	visit(ImprovedWaterFX) \
 	visit(LetterSpacing) \
 	visit(LoadModulesFromMemory) \
 	visit(LockResolution) \

--- a/Patches/HotelWater.cpp
+++ b/Patches/HotelWater.cpp
@@ -128,7 +128,7 @@ void RunHotelWater()
 
 		float Value = 0.0f;
 		// Hallway After Alternate Hotel Kitchen Water
-		if (!ImprovedWaterFX)
+		if (!WaterEnhancedRender)
 		{
 			Value = 1.75f;
 			UpdateMemoryAddress((void*)Address1, &Value, sizeof(float));		// Water texture Z stretch/shrink

--- a/Patches/WaterDrawOrderFix.cpp
+++ b/Patches/WaterDrawOrderFix.cpp
@@ -111,8 +111,11 @@ void PatchWaterDrawOrderFix()
     constexpr BYTE InitBloodDropEffectSearchBytes[]{ 0x5F, 0x66, 0xC7, 0x46, 0x08, 0x02, 0x00, 0x5E, 0xC3 };
     const DWORD InitBloodDropEffectAddr = SearchAndGetAddresses(0x004CFC33, 0x004CFEE3, 0x004CF7A3, InitBloodDropEffectSearchBytes, sizeof(InitBloodDropEffectSearchBytes), 0x16, __FUNCTION__);
 
-    constexpr BYTE WaterDepthSearchBytes[]{ 0xD9, 0x44, 0x24, 0x3C, 0x8B, 0xF0, 0xD8, 0x4E, 0x08 };
-    const DWORD WaterDepthAddr = SearchAndGetAddresses(0x004D2CDE, 0x004D2F8E, 0x004D284E, WaterDepthSearchBytes, sizeof(WaterDepthSearchBytes), 0x04, __FUNCTION__);
+    constexpr BYTE WaterDepthSearchBytesA[]{ 0xD9, 0x44, 0x24, 0x3C, 0x8B, 0xF0, 0xD8, 0x4E, 0x08 };
+    constexpr BYTE WaterDepthSearchBytesBC[]{ 0xD9, 0x44, 0x24, 0x38, 0x8B, 0xF0, 0xD8, 0x4E, 0x08 };
+    const DWORD WaterDepthAddrA = SearchAndGetAddresses(0x004D2CDE, 0x004D2F8E, 0x004D284E, WaterDepthSearchBytesA, sizeof(WaterDepthSearchBytesA), 0x04, __FUNCTION__);
+    const DWORD WaterDepthAddrB = SearchAndGetAddresses(0x004D7DA2, 0x004D8052, 0x004D7912, WaterDepthSearchBytesBC, sizeof(WaterDepthSearchBytesBC), 0x04, __FUNCTION__);
+    const DWORD WaterDepthAddrC = SearchAndGetAddresses(0x004D9542, 0x004D97F2, 0x004D90B2, WaterDepthSearchBytesBC, sizeof(WaterDepthSearchBytesBC), 0x04, __FUNCTION__);
 
     constexpr BYTE BloodPoolDepthSearchBytes[]{ 0x8B, 0x8C, 0x24, 0x88, 0x00, 0x00, 0x00, 0xC7, 0x84, 0x24, 0x8C };
     const DWORD BloodPoolDepthAddr = SearchAndGetAddresses(0x004CD10F, 0x004CD3BF, 0x004CCC7F, BloodPoolDepthSearchBytes, sizeof(BloodPoolDepthSearchBytes), 0x1F, __FUNCTION__);
@@ -123,7 +126,7 @@ void PatchWaterDrawOrderFix()
     constexpr BYTE DrawDistanceSearchBytes[]{ 0x8B, 0x44, 0x24, 0x78, 0x85, 0xC0, 0xD9, 0xFF };
     DrawDistanceAddr = ReadSearchedAddresses(0x004ED5D4, 0x004ED884, 0x004ED144, DrawDistanceSearchBytes, sizeof(DrawDistanceSearchBytes), 0x0A, __FUNCTION__);
 
-    if (!InitBloodDropEffectAddr || !WaterDepthAddr || !BloodPoolDepthAddr || !DustDepthAddr || !DrawDistanceAddr)
+    if (!InitBloodDropEffectAddr || !WaterDepthAddrA || !WaterDepthAddrB || !WaterDepthAddrC || !BloodPoolDepthAddr || !DustDepthAddr || !DrawDistanceAddr)
     {
         Logging::Log() << __FUNCTION__ << "Error: failed to find memory address!";
         return;
@@ -131,7 +134,9 @@ void PatchWaterDrawOrderFix()
 
     Logging::Log() << "Enabling Water Draw Order Fix...";
     WriteCalltoMemory((BYTE*)InitBloodDropEffectAddr, *InitBloodDropEffectASM, 0x06);
-    WriteCalltoMemory((BYTE*)WaterDepthAddr, *AdjustWaterDepthASM, 0x05);
+    WriteCalltoMemory((BYTE*)WaterDepthAddrA, *AdjustWaterDepthASM, 0x05);
+    WriteCalltoMemory((BYTE*)WaterDepthAddrB, *AdjustWaterDepthASM, 0x05);
+    WriteCalltoMemory((BYTE*)WaterDepthAddrC, *AdjustWaterDepthASM, 0x05);
     WriteCalltoMemory((BYTE*)BloodPoolDepthAddr, *AdjustUnderwaterEffectDepthASM, 0x05);
     WriteCalltoMemory((BYTE*)DustDepthAddr, *AdjustUnderwaterEffectDepthASM, 0x05);
 }

--- a/Patches/WaterDrawOrderFix.cpp
+++ b/Patches/WaterDrawOrderFix.cpp
@@ -30,7 +30,7 @@ DWORD DrawDistanceAddr = 0;
 
 bool CurrentRoomHasWater()
 {
-    // Excludes R_FOREST_CEMETERY, R_TOWN_LAKE, and R_FINAL_BOSS_RM since the player does not interact
+    // Exclude R_FOREST_CEMETERY, R_TOWN_LAKE, and R_FINAL_BOSS_RM since the player does not interact
     // directly with the water in these rooms.
     static const std::unordered_set<DWORD> rooms_with_water = {
         R_APT_W_STAIRCASE_N,
@@ -74,7 +74,7 @@ __declspec(naked) void __stdcall AdjustWaterDepthASM()
     {
         mov esi, dword ptr ds : [DrawDistanceAddr]
         fadd dword ptr ds : [esi]
-        fmul dword ptr ds : [kWaterDepthFactor]  // Depth = (Depth + DrawDistanceAddr) / 2
+        fmul dword ptr ds : [kWaterDepthFactor]  // Depth = (Depth + DrawDistance) / 2
         mov esi, eax
         fmul dword ptr ds : [esi + 0x08]  // st(0) = Depth sort index
         ret

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -639,7 +639,7 @@ void DelayedStart()
 	if (WaterEnhancedRender)
 	{
 		PatchWaterEnhancement();
-        PatchWaterDrawOrderFix();
+		PatchWaterDrawOrderFix();
 	}
 
 	// Enables a complete rewrite of the game's audio engine

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -455,7 +455,7 @@
     <ClCompile Include="Patches\CustomAdvancedOptions.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
-	<ClCompile Include="Patches\WaterDrawOrderFix.cpp">
+    <ClCompile Include="Patches\WaterDrawOrderFix.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
     <ClCompile Include="Patches\WaterEnhancement.cpp">


### PR DESCRIPTION
This PR applies several fixes to improve the appearance of water in certain areas of the game.

If `WaterEnhancedRender` is enabled:
- Fix the draw order of water objects and particle effects that appear underwater (blood pools, dust clouds). This resolves a bug where certain effects such as sprays, water splashes, and gun flashes do not render correctly on top of water.
- Prevent blood drops from spawning in rooms with water.
- Disable water UV stretching in the hallway after the Alternate Hotel Kitchen.

Other fixes:
- Adjust water opacity in the Blue Creek Apartments Stairway (first PH boss fight).
- Adjust water brightness in the Alternate Hotel Staircase after the cutscene with Angela.
- Adjust water brightness in the Alternate Hotel Kitchen.