### PR TITLE
Cancel quick saving 

### DIFF
--- a/Patches/QuickSaveCancelFix.cpp
+++ b/Patches/QuickSaveCancelFix.cpp
@@ -106,8 +106,8 @@ void RunQuickSaveCancelFix()
         SaveLoadSubState = SaveLoadState + 1;
     }
 
-    // Cancel an active quick save before entering another room or when opening the save menu
-    if (GetIsWritingQuicksave() == 1 && (GetEventIndex() == EVENT_LOAD_ROOM || GetEventIndex() == EVENT_SAVE_SCREEN))
+    // Cancel an active quick save on any event change, or when a cutscene is playing
+    if (GetIsWritingQuicksave() == 1 && (GetEventIndex() != EVENT_IN_GAME || GetCutsceneID() != CS_NONE))
     {
         *GetIsWritingQuicksavePointer() = 0;
         *SaveLoadState = 0;


### PR DESCRIPTION
Small change to `QuickSaveCancelFix` to cover more cases when deciding to cancel an active quick save since these other state changes can have unintended side effects. This fixes the following bugs:

- Quick saving and immediatrly opening the map or inventory screen prevents being able to return to the game via Esc.
- Quick saving right before a cutscene or FMV prevents being able to skip the cutscene.