### PR TITLE
Fix crash when toggling advanced filters from options

### DIFF
--- a/Patches/CustomAdvancedOptions.cpp
+++ b/Patches/CustomAdvancedOptions.cpp
@@ -636,7 +636,12 @@ namespace
         {
             if (!Option::Apply()) return false;
             *DxConfigMotionBlurEnabled = *DxConfigDepthOfFieldEnabled = (BYTE)value_index_;
-            HandleAdvancedFiltersChange();
+            __asm
+            {
+                sub esp, 0x1C
+                call HandleAdvancedFiltersChange
+                add esp, 0x1C
+            }
             return true;
         }
     };


### PR DESCRIPTION
This fix resolves a crash caused by enabling or disabling "Advanced Options > Advanced Filters" in certain rooms, e.g. Room 312 in Lakeview Hotel. The new advanced options handler was not allocating enough space on the stack before calling into code that updates advanced filters (`00464E74` - `00464EBB`), causing this code block to corrupt the stack.