### PR TITLE
Enable fog when drawing smoke particles

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -134,6 +134,7 @@
 	visit(SetSixtyFPS, true) \
 	visit(SetSwapEffectUpgradeShim, false) \
 	visit(ShowerRoomFlashlightFix, true) \
+	visit(SmokeFogFix, true) \
 	visit(Southpaw, false) \
 	visit(SpecificSoundLoopFix, true) \
 	visit(SpecularFix, true) \
@@ -281,6 +282,7 @@
 	visit(ShowerRoomFlashlightFix) \
 	visit(SmallFontHeight) \
 	visit(SmallFontWidth) \
+	visit(SmokeFogFix) \
 	visit(SpaceSize) \
 	visit(water_spec_mult_apt_staircase) \
 	visit(water_spec_mult_strange_area) \

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -2569,6 +2569,17 @@ HRESULT m_IDirect3DDevice8::DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT
 		}
 	}
 
+	// Draw smoke particles with fog enabled
+	if (SmokeFogFix && PrimitiveType == D3DPT_TRIANGLESTRIP && PrimitiveCount == 2 && VertexStreamZeroStride == 24 &&
+		pVertexStreamZeroData && GetEventIndex() == EVENT_IN_GAME)
+	{
+		CUSTOMVERTEX_TEX1 *pVertex = (CUSTOMVERTEX_TEX1*)pVertexStreamZeroData;
+		if (fabs(pVertex[0].x + 200.0f) < 1e-6 && fabs(pVertex[0].y + 400.0f) < 1e-6) {
+			ProxyInterface->SetRenderState(D3DRS_FOGENABLE, TRUE);
+			ProxyInterface->SetRenderState(D3DRS_FOGTABLEMODE, D3DFOG_LINEAR);
+		}
+	}
+
 	return ProxyInterface->DrawPrimitiveUP(PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
 }
 


### PR DESCRIPTION
Adding patch `SmokeFogFix` which enables hardware fog when drawing smoke particles. These particles occur in two places:

- From the chainsaw when finding it in the forest
- Underneath the car where the player finds the steel pipe

This reduces the intensity of the smoke effect when seen from a distance:

<img width="1230" height="408" alt="image" src="https://github.com/user-attachments/assets/656dd62b-15f5-44e6-83a0-cd978c34b98c" />

(PLMK if there is any strong opinion about keeping this enabled by default. Some players may actually prefer the current behavior since the bright smoke might make it easier to spot these pickups from afar. In either case, there is still an audio cue to help guide them.)