### PR TITLE
Prevent Maria from spawning out of bounds in certain rooms

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -106,6 +106,7 @@
 	visit(MainMenuFix, true) \
 	visit(MainMenuInstantLoadOptions, true) \
 	visit(MainMenuTitlePerLang, true) \
+	visit(MariaSpawnFix, true) \
 	visit(MemoScreenFix, true) \
 	visit(MenuSoundsFix, true) \
 	visit(MothDrawOrderFix, true) \
@@ -268,6 +269,7 @@
 	visit(LimitPerFrameFPS) \
 	visit(LoadModulesFromMemory) \
 	visit(LockResolution) \
+	visit(MariaSpawnFix) \
 	visit(MusicBoxVolume) \
 	visit(NormalFontHeight) \
 	visit(NormalFontWidth) \

--- a/Patches/MariaSpawnFix.cpp
+++ b/Patches/MariaSpawnFix.cpp
@@ -1,0 +1,49 @@
+/**
+* Copyright (C) 2025 Murugo
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Patches.h"
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+
+// Prevents Maria from spawning out of bounds in certain rooms after reuniting with her outside of
+// Pete's Bowl-O-Rama or in the basement of the Otherworld Hospital.
+void RunMariaSpawnFix()
+{
+	// If enabled, when loading the next room, the game will set Maria's position to her last saved
+	// position from the current save file.
+	static WORD* UseSavedPos = nullptr;
+
+	if (!UseSavedPos)
+	{
+		RUNONCE();
+
+		constexpr BYTE SearchBytes[]{ 0x33, 0xC9, 0xB8, 0x21, 0x00, 0x00, 0x00, 0xBA };
+		UseSavedPos = (WORD*)ReadSearchedAddresses(0x0052D9FB, 0x0052DD2B, 0x0052D64B, SearchBytes, sizeof(SearchBytes), -0x21, __FUNCTION__);
+		if (!UseSavedPos)
+		{
+			Logging::Log() << __FUNCTION__ << " Error: failed to find memory address!";
+			return;
+		}
+	}
+
+	if (GetCutsceneID() == CS_BOWL_MARIA_JAMES || GetCutsceneID() == CS_HSP_ALT_MARIA_BASEMENT ||
+		(GetRoomID() == R_HSP_ALT_BASEMENT && GetEventIndex() == EVENT_GAME_FMV))
+	{
+		*UseSavedPos = 0;
+	}
+}

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -766,6 +766,7 @@ void RunHotelWater();
 void RunInfiniteRumbleFix();
 void RunInnerFlashlightGlow(DWORD Height);
 void RunLightingTransition();
+void RunMariaSpawnFix();
 void RunPlayFlashlightSounds();
 void RunPlayLyingFigureSounds();
 void RunQuickSaveTweaks();

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -2771,6 +2771,12 @@ HRESULT m_IDirect3DDevice8::BeginScene()
 			RunChainsawSoundFix();
 		}
 
+		// Prevent Maria from spawning out of bounds in certain rooms
+		if (MariaSpawnFix)
+		{
+			RunMariaSpawnFix();
+		}
+
 		NeedToGrabScreenForWater = true;
 		RoachesDrawingCounter = 0;
 	}

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -230,6 +230,7 @@ copy /Y "$(ProjectDir)Resources\SH2EEsetup.exe" "$(TargetDir)" &gt;nul</Command>
     <ClCompile Include="Patches\MapTranscription.cpp" />
     <ClCompile Include="Patches\DelayedFadeIn.cpp" />
     <ClCompile Include="Patches\FmvSubtitles.cpp" />
+    <ClCompile Include="Patches\MariaSpawnFix.cpp" />
     <ClCompile Include="Patches\MusicBoxVolume.cpp" />
     <ClCompile Include="Patches\OptionsMenuTweaks.cpp" />
     <ClCompile Include="Patches\PuzzleAlignmentFixes.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -491,6 +491,9 @@
     <ClCompile Include="Patches\DogRoomEnhanced.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\MariaSpawnFix.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
Adding patch `MariaSpawnFix` that avoids two instances where Maria will spawn at an invalid location after entering a room.

This bug is caused by incorrect handling of a flag (`00932000 (short)`) that forces Maria to spawn at her last saved location. This flag usually takes effect when loading a save, but doesn't reset properly if Maria is in a state where she is not following James.

Steps to reproduce (with the patch disabled):

- Pete's Bowl-O-Rama:
  - Enter the bowling alley and create a save.
  - Load the last save.
  - Continue playing until reuniting with Maria outside of the bowling alley.
  - Enter the gate to the alley behind the building. Instead of appearing next to James, Maria will spawn at her last saved location, which is outside the entrance to the bowling alley.
- Brookhaven Hospital:
  - Leave Maria in room S3. Create a save outside of the room.
  - Load the last save.
  - Continue playing until entering the basement in the otherworld hospital.
  - After reuniting with Maria, climb down the ladder to the basement's basement. Instead of appearing in the corner of the room, Maria will spawn at (0, 0, 0).