### PR TITLE
Add in-memory playback for WAV audio stored in AFS

### DIFF
--- a/Common/ScopeGuard.h
+++ b/Common/ScopeGuard.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+struct ScopedCriticalSection
+{
+private:
+    bool enable;
+    CRITICAL_SECTION* cs;
+public:
+    // Constructor enters critical section
+    ScopedCriticalSection(CRITICAL_SECTION* cs, bool setenable = true) : cs(cs), enable(setenable)
+    {
+        if (enable && cs)
+        {
+            EnterCriticalSection(cs);
+        }
+    }
+    // Destructor leaves critical section
+    ~ScopedCriticalSection()
+    {
+        if (enable && cs)
+        {
+            LeaveCriticalSection(cs);
+        }
+    }
+};

--- a/Patches/PlayUnusedAudio.cpp
+++ b/Patches/PlayUnusedAudio.cpp
@@ -1,6 +1,5 @@
 // playunusedaudio.cpp
 #include <windows.h>
-#include <dsound.h>
 #include <fstream>
 #include <vector>
 #include <cstdint>
@@ -8,282 +7,106 @@
 #include "Common\FileSystemHooks.h"
 #include "Common\Settings.h"
 #include "Patches.h"
-#include "InputTweaks.h"
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+#include "Wrappers/dsound/dsoundwrapper.h"
 #include <shlwapi.h>
 
-template <typename T>
-struct ComReleaser
-{
-    T* ptr;
 
-    ComReleaser(T* p = nullptr) : ptr(p) {}
-
-    ~ComReleaser()
-    {
-        if (ptr)
-        {
-            ptr->Release();
-            ptr = nullptr;
-        }
-    }
-    // Conversion to raw pointer
-    operator T* () const { return ptr; }
-    T** operator&() { return &ptr; }
-    T* operator->() const { return ptr; }
-};
-
-struct AutoLock 
-{
-    CRITICAL_SECTION* cs;
-    AutoLock(CRITICAL_SECTION* c) : cs(c) { EnterCriticalSection(cs); }
-    ~AutoLock() { LeaveCriticalSection(cs); }
-};
 
 void PatchUnusedAudio();
-extern "C" HRESULT WINAPI DSOAL_DirectSoundCreate8(LPCGUID lpcGUID, IDirectSound8** ppDS, IUnknown* pUnkOuter);
 
 volatile LONG g_forceAction = 0;
 
-
 struct AfsEntry { uint32_t offset; uint32_t size; };
-
-extern KeyBindsHandler KeyBinds;
-extern InputTweaks InputTweaksRef;
 
 static std::string g_dllDir;
 static std::string voicepath;
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
-static IDirectSound8* g_pDS = nullptr;
-static IDirectSoundBuffer* g_pBuffer = nullptr;
-static CRITICAL_SECTION g_audioLock;
-static bool g_audioLockInitialized = false;
-
 static std::vector<AfsEntry> g_afsTable;
 static volatile LONG gStarted = 0;
 
+constexpr DWORD UnusedLauraLetterBufferID = 4;
 
-
-volatile LONG g_blockPlayerInputs = 0; // set to 1 to block inputs for autoplay
-volatile LONG g_stopAutoplay = 0;     // set to 1 to request immediate stop autoplay
+volatile LONG g_blockPlayerInputs = 0;
+volatile LONG g_stopAutoplay = 0;
 
 static void StopAlertSound()
 {
-    // caller must own g_audioLock
-    if (g_pBuffer)
-    {
-        g_pBuffer->Stop();
-        g_pBuffer->Release();
-        g_pBuffer = nullptr;
-        Logging::LogDebug() << __FUNCTION__ << " buffer stopped and released.";
-    }
-}
-
-// Initialize global DirectSound device only once.
-static bool EnsureDirectSoundInitialized()
-{
-    if (!g_audioLockInitialized)
-    {
-        InitializeCriticalSection(&g_audioLock);
-        g_audioLockInitialized = true;
-    }
-
-    if (g_pDS) return true;
-
-    IDirectSound8* pDS = nullptr;
-    HRESULT hr = DSOAL_DirectSoundCreate8(nullptr, &pDS, nullptr);
-    if (FAILED(hr) || !pDS)
-    {
-        Logging::LogDebug() << __FUNCTION__ << " DSOAL_DirectSoundCreate8 failed hr=0x%08X";
-        return false;
-    }
-
-    HWND hwnd = GetForegroundWindow();
-    if (!hwnd) hwnd = GetDesktopWindow();
-    pDS->SetCooperativeLevel(hwnd, DSSCL_PRIORITY);
-
-    // keep global
-    g_pDS = pDS;
-    Logging::LogDebug() << __FUNCTION__ << " DirectSound device created.";
-    return true;
+    m_IDirectSound8::StopWavFile(UnusedLauraLetterBufferID);
 }
 
 static bool LoadFileToMemory(const std::string& path, std::vector<BYTE>& outBuf)
 {
     std::ifstream f(path, std::ios::binary | std::ios::ate);
-    if (!f.is_open()) 
+    if (!f.is_open())
         return false;
     std::streamsize size = f.tellg();
-    if (size <= 0) 
+    if (size <= 0)
         return false;
     outBuf.resize((size_t)size);
     f.seekg(0, std::ios::beg);
-    if (!f.read((char*)outBuf.data(), size)) 
+    if (!f.read((char*)outBuf.data(), size))
     {
         outBuf.clear();
-        return false; 
+        return false;
     }
+
     return true;
 }
 
-// Applies master volume by multiplying every PCM sample.
-static void ApplyGameMasterVolume(BYTE* buffer, DWORD sizeBytes, float volume)
-{
-    short* samples = (short*)buffer;
-    DWORD sampleCount = sizeBytes / sizeof(short);
-    for (DWORD i = 0; i < sampleCount; i++)
-    {
-        int v = (int)(samples[i] * volume);
-        if (v > 32767) v = 32767;
-        if (v < -32768) v = -32768;
-        samples[i] = (short)v;
-    }
-}
-
-// Create a DirectSound buffer and play the WAV PCM data.
-static bool PlayWavWithDirectSound(const WAVEFORMATEX* wf, const BYTE* audioData, DWORD audioSize)
-{
-    if (!wf || !audioData || audioSize == 0)
-        return false;
-    if (!EnsureDirectSoundInitialized()) 
-        return false;
-
-    AutoLock lock(&g_audioLock);
-
-    // Stop and destroy the previous buffer
-    if (g_pBuffer)
-    {
-        g_pBuffer->Stop();
-        g_pBuffer->Release();
-        g_pBuffer = nullptr;
-    }
-
-    DSBUFFERDESC desc = {};
-    desc.dwSize = sizeof(desc);
-    desc.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_LOCSOFTWARE | DSBCAPS_GLOBALFOCUS;
-    desc.dwBufferBytes = audioSize;
-    desc.lpwfxFormat = (LPWAVEFORMATEX)wf;
-
-    // RAII for new buffer
-    ComReleaser<IDirectSoundBuffer> localBuffer;
-    // Create sound buffer
-    HRESULT hr = g_pDS->CreateSoundBuffer(&desc, &localBuffer, nullptr);
-    if (FAILED(hr))
-    {
-        Logging::LogDebug() << __FUNCTION__ << " CreateSoundBuffer failed (hr=0x%08X)", (unsigned)hr;
-        return false;
-    }
-
-    void* p1 = nullptr; DWORD b1 = 0;
-    void* p2 = nullptr; DWORD b2 = 0;
-    hr = localBuffer->Lock(0, audioSize, &p1, &b1, &p2, &b2, 0);
-    if (FAILED(hr)) 
-    {
-        Logging::LogDebug() << __FUNCTION__ << " Lock failed (hr=0x%08X)", (unsigned)hr;
-        return false;  
-    }
-
-    if (p1 && b1) memcpy(p1, audioData, b1);
-    if (p2 && b2) memcpy(p2, audioData + b1, b2);
-    localBuffer->Unlock(p1, b1, p2, b2);
-
-    hr = localBuffer->Play(0, 0, 0);
-    if (FAILED(hr))
-    {
-        Logging::LogDebug() << __FUNCTION__ << " Lock failed (hr=0x%08X)", (unsigned)hr;
-        return false;
-    }
-
-    // Transfer ownership
-    g_pBuffer = localBuffer.ptr;
-    localBuffer.ptr = nullptr;
-    Logging::LogDebug() << __FUNCTION__ << " playback OK (%u bytes).", audioSize;
-    return true;
-}
-
-
-
-// Plays only a slice of a WAV file (start/end seconds).
+// Plays only a slice of a WAV buffer (start/end seconds) directly from memory
 static void PlayWavFromMemoryRange(BYTE* wavBuf, size_t wavSize, float startSec, float endSec)
 {
-    if (!wavBuf || wavSize < 44) 
-    {
-        Logging::LogDebug() << __FUNCTION__ << " invalid buffer/size";
-        return; 
-    }
+    if (!wavBuf || wavSize < 44)
+        return;
 
     uint32_t fmtSize = *(uint32_t*)(wavBuf + 16);
+    if (fmtSize < 16)
+        return;
+
     WAVEFORMATEX* wf = (WAVEFORMATEX*)(wavBuf + 20);
 
-    if (fmtSize < 16 || !wf->nSamplesPerSec || !wf->wBitsPerSample) 
-    { 
-        Logging::LogDebug() << __FUNCTION__ << " invalid WAV header.";
-        return; 
-    }
-
     DWORD dataPos = 20 + fmtSize + 8;
-    if (dataPos >= wavSize) 
-    { 
-        Logging::LogDebug() << __FUNCTION__ << " dataPos >= wavSize";
-        return; 
-    }
+    if (dataPos >= wavSize)
+        return;
 
     BYTE* audio = wavBuf + dataPos;
     DWORD audioSize = (DWORD)(wavSize - dataPos);
     DWORD frameBytes = (wf->wBitsPerSample / 8) * wf->nChannels;
+    if (frameBytes == 0 || wf->nSamplesPerSec == 0)
+        return;
 
     DWORD start = (DWORD)(startSec * wf->nSamplesPerSec * frameBytes);
     DWORD end = (DWORD)(endSec * wf->nSamplesPerSec * frameBytes);
 
     if (start > audioSize) start = 0;
     if (end > audioSize) end = audioSize;
-    if (end <= start) 
-    { 
-        Logging::LogDebug() << __FUNCTION__ << " invalid PCM range.";
-    return;
-    }
+    if (end <= start) return;
 
     DWORD playLen = end - start;
     std::vector<BYTE> pcm(playLen);
     memcpy(pcm.data(), audio + start, playLen);
 
-    float vol = EnableMasterVolume ? (float)ConfigData.VolumeLevel / 15.0f : 1.0f;
-    if (wf->wFormatTag == WAVE_FORMAT_PCM && wf->wBitsPerSample == 16)
-        ApplyGameMasterVolume(pcm.data(), playLen, vol);
-
-    if (!PlayWavWithDirectSound(wf, pcm.data(), playLen)) 
-    { 
-        Logging::LogDebug() << __FUNCTION__ << " ERROR: DirectSound failed to play PCM.";
-        return; 
-    }
-    Logging::LogDebug() << __FUNCTION__ << " playback OK.";
+    m_IDirectSound8::StopWavFile(UnusedLauraLetterBufferID);
+    m_IDirectSound8::PlayWavMemory(wf, pcm.data(), playLen, UnusedLauraLetterBufferID, false);
 }
 
 static void InitVoiceAFS()
 {
     std::vector<BYTE> buf;
-    if (!LoadFileToMemory(voicepath, buf)) 
-    { 
-        Logging::LogDebug() << __FUNCTION__ << " failed to open AFS file.";
-        return; 
-    }
-    if (buf.size() < 16 || memcmp(buf.data(), "AFS\0", 4) != 0) 
-    { 
-        Logging::LogDebug() << __FUNCTION__ << " invalid AFS file.";
-        return; 
-    }
+    if (!LoadFileToMemory(voicepath, buf))
+        return;
+    if (buf.size() < 16 || memcmp(buf.data(), "AFS\0", 4) != 0)
+        return;
 
     uint32_t fileCount = *(uint32_t*)(buf.data() + 4);
-    Logging::LogDebug() << __FUNCTION__ << " fileCount=%u", fileCount;
-
 
     size_t tableStart = 8;
     size_t tableSize = (size_t)fileCount * 8;
-    if (tableStart + tableSize > buf.size()) 
-    { 
-        Logging::LogDebug() << __FUNCTION__ << " offset/size table exceeds file size.";
-        return; 
-    }
+    if (tableStart + tableSize > buf.size())
+        return;
 
     g_afsTable.resize(fileCount);
     for (uint32_t i = 0; i < fileCount; ++i)
@@ -292,39 +115,26 @@ static void InitVoiceAFS()
         g_afsTable[i].offset = *(uint32_t*)(buf.data() + p);
         g_afsTable[i].size = *(uint32_t*)(buf.data() + p + 4);
     }
-    Logging::LogDebug() << __FUNCTION__ << " offset/size table loaded.";
 }
 
 static bool PlayVoiceAfs(uint32_t index, float startSec, float endSec)
 {
-    if (index >= g_afsTable.size()) 
-    { 
-        Logging::LogDebug() << __FUNCTION__ << " invalid index %u", index;
-        return false; 
-    }
+    if (index >= g_afsTable.size())
+        return false;
     const AfsEntry& e = g_afsTable[index];
-    Logging::LogDebug() << __FUNCTION__ << " index=%u offset=0x%X size=%u", index, e.offset, e.size;
     std::ifstream f(voicepath, std::ios::binary);
-    if (!f.is_open()) 
-    { 
-        Logging::LogDebug() << __FUNCTION__ << " cannot open AFS.";
+    if (!f.is_open())
+        return false;
 
-        return false; 
-    }
     f.seekg(e.offset, std::ios::beg);
 
     std::vector<BYTE> wavData(e.size);
-    if (!f.read((char*)wavData.data(), e.size)) 
-    { 
-        Logging::LogDebug() << __FUNCTION__ << " reading block failed.";
-        return false; 
-    }
+    if (!f.read((char*)wavData.data(), e.size))
+        return false;
 
     PlayWavFromMemoryRange(wavData.data(), wavData.size(), startSec, endSec);
     return true;
 }
-
-
 
 static bool ShouldActivateSequence(DWORD room, DWORD cutscene, DWORD fade, float cutsceneTime)
 {
@@ -364,7 +174,6 @@ void ResolveLastTextPtr()
     }
 
     DWORD absolute = *(DWORD*)(addr + 3);
-
     g_lastTextValuePtr = (volatile WORD*)absolute;
 
     Logging::LogDebug() << __FUNCTION__ << " Resolved last-text ptr = %p", g_lastTextValuePtr;
@@ -393,8 +202,6 @@ void SetLastTextValueTo9()
     }
 }
 
-
-//It will only press the buttons automatically if the SH2:EE window is in focus.
 static bool WaitForGameFocusOrStop(DWORD sleepMs = 50)
 {
     while (GetForegroundWindow() != GameWindowHandle)
@@ -407,14 +214,13 @@ static bool WaitForGameFocusOrStop(DWORD sleepMs = 50)
     return true;
 }
 
-static void InjectAction() 
+static void InjectAction()
 {
     InterlockedExchange(&g_forceAction, 1);
     Sleep(80);
     InterlockedExchange(&g_forceAction, 0);
 }
 
-// Called from InputTweaks when player presses Skip during sequence
 void StopAutoplayImmediate()
 {
     Logging::LogDebug() << __FUNCTION__ << " stopping autoplay.";
@@ -427,50 +233,54 @@ void StopAutoplayImmediate()
     InterlockedExchange(&g_forceAction, 1);
 }
 
-inline LONG AtomicRead(volatile LONG* target) {
+inline LONG AtomicRead(volatile LONG* target)
+{
     return InterlockedCompareExchange(target, 0, 0);
 }
 
-
-DWORD WINAPI AudioMonitorThread(LPVOID) {
+DWORD WINAPI AudioMonitorThread(LPVOID)
+{
     static const float seqStart[] = { 0.0f, 7.2f, 13.0f, 17.1f, 19.2f, 22.5f, 35.2f, 47.2f, 53.4f, 61.2f, 64.0f };
     static const float seqEnd[] = { 7.0f, 12.4f, 16.9f, 19.0f, 22.0f, 34.5f, 46.2f, 52.2f, 60.2f, 63.5f, 67.2f };
 
-    while (true) {
+    while (true)
+    {
         Sleep(100);
 
-        if (GetRoomID() != R_HTL_RESTAURANT) {
-            if (InterlockedExchange(&g_blockPlayerInputs, 0) == 1) StopAlertSound();
+        if (GetRoomID() != R_HTL_RESTAURANT)
+        {
+            if (InterlockedExchange(&g_blockPlayerInputs, 0) == 1)
+                StopAlertSound();
             continue;
         }
 
-        if (ShouldActivateSequence(GetRoomID(), GetCutsceneID(), GetTransitionState(), GetCutsceneTimer())) 
+        if (ShouldActivateSequence(GetRoomID(), GetCutsceneID(), GetTransitionState(), GetCutsceneTimer()))
         {
             InterlockedExchange(&g_blockPlayerInputs, 1);
             InterlockedExchange(&g_stopAutoplay, 0);
 
             Sleep(1500);
-            if (WaitForGameFocusOrStop()) 
+            if (WaitForGameFocusOrStop())
                 InjectAction();
 
-            for (int i = 0; i < 11; ++i) 
+            for (int i = 0; i < 11; ++i)
             {
-                // Safety check: Exit loop if player skipped the cutscene
                 if (AtomicRead(&g_stopAutoplay)) break;
                 if (!StabilizeCutscene()) break;
 
                 PlayVoiceAfs(119, seqStart[i], seqEnd[i]);
 
-                // Controlled wait loop allowing responsive interruption
                 DWORD waitMs = (DWORD)((seqEnd[i] - seqStart[i]) * 1000.0f) + 200;
-                for (DWORD t = 0; t < waitMs; t += 50) {
+                for (DWORD t = 0; t < waitMs; t += 50)
+                {
                     if (AtomicRead(&g_stopAutoplay) || !StabilizeCutscene())
                         goto end_sequence;
-                    
+
                     Sleep(50);
                 }
 
-                if (WaitForGameFocusOrStop()) {
+                if (WaitForGameFocusOrStop())
+                {
                     InjectAction();
                     Sleep(100);
                 }
@@ -480,14 +290,13 @@ DWORD WINAPI AudioMonitorThread(LPVOID) {
             StopAlertSound();
             InterlockedExchange(&g_blockPlayerInputs, 0);
 
-            while (StabilizeCutscene() && !AtomicRead(&g_stopAutoplay)) 
+            while (StabilizeCutscene() && !AtomicRead(&g_stopAutoplay))
                 Sleep(200);
         }
     }
     return 0;
 }
 
-// Entry point: locate memory address, verify AFS, start monitor thread.
 void PatchUnusedAudio()
 {
     if (GameVersion != SH2V_10 && GameVersion != SH2V_11)
@@ -496,12 +305,14 @@ void PatchUnusedAudio()
         return;
     }
 
-    if (InterlockedExchange(&gStarted, 1) != 0) 
+    if (InterlockedExchange(&gStarted, 1) != 0)
         return;
 
-    char path[MAX_PATH]; 
+    char path[MAX_PATH];
     GetModuleFileNameA(NULL, path, MAX_PATH);
-    std::string s = path; size_t p = s.find_last_of("\\/"); if (p != std::string::npos) s = s.substr(0, p);
+    std::string s = path;
+    size_t p = s.find_last_of("\\/");
+    if (p != std::string::npos) s = s.substr(0, p);
     g_dllDir = s;
 
     Logging::LogDebug() << __FUNCTION__ << " Starting PlayUnusedAudio...";

--- a/Patches/PlayUnusedAudio.cpp
+++ b/Patches/PlayUnusedAudio.cpp
@@ -12,8 +12,6 @@
 #include "Wrappers/dsound/dsoundwrapper.h"
 #include <shlwapi.h>
 
-
-
 void PatchUnusedAudio();
 
 volatile LONG g_forceAction = 0;
@@ -27,14 +25,14 @@ extern "C" IMAGE_DOS_HEADER __ImageBase;
 static std::vector<AfsEntry> g_afsTable;
 static volatile LONG gStarted = 0;
 
-constexpr DWORD UnusedLauraLetterBufferID = 4;
+constexpr DWORD UnusedLauraLetterBufferID = 3;
 
 volatile LONG g_blockPlayerInputs = 0;
 volatile LONG g_stopAutoplay = 0;
 
 static void StopAlertSound()
 {
-    m_IDirectSound8::StopWavFile(UnusedLauraLetterBufferID);
+    m_IDirectSound8::StopWavSoundBuffer(UnusedLauraLetterBufferID);
 }
 
 static bool LoadFileToMemory(const std::string& path, std::vector<BYTE>& outBuf)
@@ -89,7 +87,7 @@ static void PlayWavFromMemoryRange(BYTE* wavBuf, size_t wavSize, float startSec,
     std::vector<BYTE> pcm(playLen);
     memcpy(pcm.data(), audio + start, playLen);
 
-    m_IDirectSound8::StopWavFile(UnusedLauraLetterBufferID);
+    m_IDirectSound8::StopWavSoundBuffer(UnusedLauraLetterBufferID);
     m_IDirectSound8::PlayWavMemory(wf, pcm.data(), playLen, UnusedLauraLetterBufferID, false);
 }
 

--- a/Patches/PlayWavSound.cpp
+++ b/Patches/PlayWavSound.cpp
@@ -49,7 +49,7 @@ static int32_t PlaySaveSound(int32_t SoundId, float volume, DWORD param3)
 	UNREFERENCED_PARAMETER(volume);
 	UNREFERENCED_PARAMETER(param3);
 
-	m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + SaveGameWav).c_str(), SaveID);
+	m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + SaveGameWav).c_str(), SaveID, true);
 
 	return 0x10;	// PlaySound function success
 }
@@ -60,7 +60,7 @@ static int32_t PlayLoadSound(int32_t SoundId, float volume, DWORD param3)
 	UNREFERENCED_PARAMETER(volume);
 	UNREFERENCED_PARAMETER(param3);
 
-	m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + LoadGameWav).c_str(), LoadID);
+	m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + LoadGameWav).c_str(), LoadID, true);
 
 	return 0x10;	// PlaySound function success
 }
@@ -243,12 +243,12 @@ void RunPlayFlashlightSounds()
 		// play flashlight_off.wav
 		if (FlashLightSwitch == 0)
 		{
-			m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + FlashLightOffWav).c_str(), FlashlightID);
+			m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + FlashLightOffWav).c_str(), FlashlightID, true);
 		}
 		// play flashlight_on.wav
 		else if (FlashLightSwitch == 1)
 		{
-			m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + FlashLightOnWav).c_str(), FlashlightID);
+			m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + FlashLightOnWav).c_str(), FlashlightID, true);
 		}
 	}
 	LastRoomID = RoomID;
@@ -290,7 +290,7 @@ void RunPlayLyingFigureSounds()
 			MatchFound = true;
 			DWORD Value = 0x00000000;
 			UpdateMemoryAddress(LyingFigureFootstepSFX, &Value, sizeof(Value));
-			m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + LyingFigureFootstepWav).c_str(), FootstepsID);
+			m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + LyingFigureFootstepWav).c_str(), FootstepsID, true);
 		}
 	}
 	else if (MatchFound)
@@ -298,7 +298,7 @@ void RunPlayLyingFigureSounds()
 		MatchFound = false;
 		DWORD Value = 0x00002EF3;
 		UpdateMemoryAddress(LyingFigureFootstepSFX, &Value, sizeof(Value));
-		m_IDirectSound8::StopWavFile(FootstepsID);
+		m_IDirectSound8::StopWavSoundBuffer(FootstepsID);
 	}
 }
 
@@ -336,12 +336,12 @@ void RunPlayClosetCutsceneBonusAudio()
 		if (!MatchFound)
 		{
 			MatchFound = true;
-			m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + ClosetCutsceneBonusAudioWav).c_str(), ClosetCutsceneID);
+			m_IDirectSound8::PlayWavFile((std::string(GetModPath("")) + ClosetCutsceneBonusAudioWav).c_str(), ClosetCutsceneID, true);
 		}
 	}
 	else if (MatchFound)
 	{
 		MatchFound = false;
-		m_IDirectSound8::StopWavFile(ClosetCutsceneID);
+		m_IDirectSound8::StopWavSoundBuffer(ClosetCutsceneID);
 	}
 }

--- a/Resources/BuildNo.rc
+++ b/Resources/BuildNo.rc
@@ -1,1 +1,1 @@
-#define BUILD_NUMBER 2252 
+#define BUILD_NUMBER 2253 

--- a/Wrappers/dsound/IDirectSound8.cpp
+++ b/Wrappers/dsound/IDirectSound8.cpp
@@ -21,7 +21,7 @@
 
 namespace {
 	CRITICAL_SECTION dscs = {};
-	constexpr DWORD MaxBuffers = 4;
+	constexpr DWORD MaxBuffers = 5;
 	m_IDirectSound8* pCurrentDirectSound = nullptr;
 	m_IDirectSoundBuffer8* pDirectSoundWavBuffer[MaxBuffers] = {};
 }
@@ -513,4 +513,112 @@ void m_IDirectSound8::ReleaseSoundBuffer(DWORD BifferID)
 		}
 		pDirectSoundWavBuffer[BifferID] = nullptr;
 	}
+}
+HRESULT m_IDirectSound8::PlayWavMemory(const WAVEFORMATEX* waveFormat, const BYTE* audioData, DWORD audioSize, DWORD BufferID, bool useSfxVolume)
+{
+	if (!waveFormat || !audioData || audioSize == 0)
+	{
+		Logging::Log() << __FUNCTION__ << " Error: bad audio parameters!";
+		return DSERR_INVALIDPARAM;
+	}
+
+	if (BufferID + 1 > MaxBuffers)
+	{
+		Logging::Log() << __FUNCTION__ << " Error: invalid buffer ID!";
+		return DSERR_INVALIDPARAM;
+	}
+
+	if (!pCurrentDirectSound)
+	{
+		Logging::Log() << __FUNCTION__ << " Error: current DirectSound8 not setup!";
+		return DSERR_DS8_REQUIRED;
+	}
+
+	EnterCriticalSection(&dscs);
+
+	// Release all buffers that are not playing
+	for (DWORD x = 0; x < MaxBuffers; x++)
+	{
+		if (pDirectSoundWavBuffer[x])
+		{
+			DWORD Status = 0;
+			if (SUCCEEDED(pDirectSoundWavBuffer[x]->GetStatus(&Status)) && !(Status & DSBSTATUS_PLAYING))
+			{
+				ReleaseSoundBuffer(x);
+			}
+		}
+	}
+
+	// Release current buffer
+	ReleaseSoundBuffer(BufferID);
+
+	DSBUFFERDESC dsbd = {};
+	dsbd.dwSize = sizeof(DSBUFFERDESC);
+	dsbd.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY | DSBCAPS_CTRLPAN | DSBCAPS_CTRLPOSITIONNOTIFY;
+	dsbd.dwBufferBytes = audioSize;
+	dsbd.lpwfxFormat = const_cast<WAVEFORMATEX*>(waveFormat);
+
+	LPDIRECTSOUNDBUFFER pBuffer = nullptr;
+	HRESULT hr = pCurrentDirectSound->CreateSoundBuffer(&dsbd, &pBuffer, nullptr);
+	if (FAILED(hr) || !pBuffer)
+	{
+		LeaveCriticalSection(&dscs);
+		Logging::Log() << __FUNCTION__ << " Error: CreateSoundBuffer failed!";
+		return FAILED(hr) ? hr : DSERR_GENERIC;
+	}
+
+	m_IDirectSoundBuffer8* pWrappedBuffer = (m_IDirectSoundBuffer8*)pBuffer;
+
+	LPVOID pData1 = nullptr;
+	DWORD dataSize1 = 0;
+	LPVOID pData2 = nullptr;
+	DWORD dataSize2 = 0;
+
+	hr = pWrappedBuffer->Lock(0, audioSize, &pData1, &dataSize1, &pData2, &dataSize2, DSBLOCK_ENTIREBUFFER);
+	if (FAILED(hr))
+	{
+		pWrappedBuffer->Release();
+		LeaveCriticalSection(&dscs);
+		Logging::Log() << __FUNCTION__ << " Error: Lock failed!";
+		return hr;
+	}
+
+	if (pData1 && dataSize1)
+	{
+		memcpy(pData1, audioData, dataSize1);
+	}
+	if (pData2 && dataSize2)
+	{
+		memcpy(pData2, audioData + dataSize1, dataSize2);
+	}
+
+	pWrappedBuffer->Unlock(pData1, dataSize1, pData2, dataSize2);
+
+	LONG Volume = DSBVOLUME_MAX;
+	if (useSfxVolume)
+	{
+		BYTE SFXVolumeLevel = GetSFXVolume();
+		if (SFXVolumeLevel < 16)
+		{
+			Volume = VolumeArray[SFXVolumeLevel];
+		}
+	}
+
+	pWrappedBuffer->SetVolume(Volume);
+
+	hr = pWrappedBuffer->Play(0, 0, 0);
+	if (FAILED(hr))
+	{
+		pWrappedBuffer->Release();
+		LeaveCriticalSection(&dscs);
+		Logging::Log() << __FUNCTION__ << " Error: Play failed!";
+		return hr;
+	}
+
+	pDirectSoundWavBuffer[BufferID] = pWrappedBuffer;
+
+	Logging::LogDebug() << __FUNCTION__ << " Playing in-memory WAV buffer.";
+
+	LeaveCriticalSection(&dscs);
+	return hr;
 }

--- a/Wrappers/dsound/IDirectSound8.cpp
+++ b/Wrappers/dsound/IDirectSound8.cpp
@@ -17,11 +17,12 @@
 #include "dsoundwrapper.h"
 #include <fstream>
 #include <shlwapi.h>
+#include "Common\ScopeGuard.h"
 #include "Patches\Patches.h"
 
 namespace {
 	CRITICAL_SECTION dscs = {};
-	constexpr DWORD MaxBuffers = 5;
+	constexpr DWORD MaxBuffers = 4;		// 0 = Save; 1 = Load; 2 = Flashlight; 3 = Footsteps/ClosetCutscene/UnusedLauraLetter
 	m_IDirectSound8* pCurrentDirectSound = nullptr;
 	m_IDirectSoundBuffer8* pDirectSoundWavBuffer[MaxBuffers] = {};
 }
@@ -69,7 +70,7 @@ ULONG m_IDirectSound8::Release()
 	{
 		for (DWORD x = 0; x < MaxBuffers; x++)
 		{
-			ReleaseSoundBuffer(x);
+			ReleaseWavSoundBuffer(x);
 		}
 		count = ProxyInterface->Release();	// Release extra ref count
 	}
@@ -227,7 +228,7 @@ void m_IDirectSound8::ReleaseDevice()
 	dscs = {};
 }
 
-HRESULT m_IDirectSound8::CreateWAVSoundBuffer(const char* filePath, m_IDirectSoundBuffer8** ppDSBuffer)
+HRESULT m_IDirectSound8::CreateWavSoundBuffer(DWORD BufferID, DSBUFFERDESC& dsbd, m_IDirectSoundBuffer8** ppDSBuffer)
 {
 	// Check buffer
 	if (!ppDSBuffer)
@@ -235,43 +236,61 @@ HRESULT m_IDirectSound8::CreateWAVSoundBuffer(const char* filePath, m_IDirectSou
 		Logging::Log() << __FUNCTION__ << " Error: bad buffer address!";
 		return DSERR_INVALIDPARAM;
 	}
+	*ppDSBuffer = nullptr;
 
-	// Buffer variables
-	DSBUFFERDESC dsbd = {};
-	WAVEFORMATEX waveFormat = {};
-	std::vector<char> AudioBuffer;
-
-	// Parse WAV files
-	HRESULT hr = ParseWavFile(filePath, dsbd, waveFormat, AudioBuffer);
-	if (FAILED(hr))
+	// Check buffer ID
+	if (BufferID + 1 > MaxBuffers)
 	{
-		Logging::Log() << __FUNCTION__ << " Error: failed to load WAV! file: " << filePath << " hr: " << (DSERR)hr;
-		return hr;
+		Logging::Log() << __FUNCTION__ << " Error: invalid buffer ID! " << BufferID;
+		return DSERR_INVALIDPARAM;
 	}
+
+	// Release all buffers that are not playing
+	for (DWORD x = 0; x < MaxBuffers; x++)
+	{
+		if (pDirectSoundWavBuffer[x])
+		{
+			DWORD Status = 0;
+			if (SUCCEEDED(pDirectSoundWavBuffer[x]->GetStatus(&Status)) && !(Status & DSBSTATUS_PLAYING))
+			{
+				ReleaseWavSoundBuffer(x);
+			}
+		}
+	}
+
+	// Release current buffer
+	ReleaseWavSoundBuffer(BufferID);
 
 	// Create a sound buffer
 	LPDIRECTSOUNDBUFFER pBuffer = nullptr;
-	hr = ProxyInterface->CreateSoundBuffer(&dsbd, &pBuffer, nullptr);
+	HRESULT hr = ProxyInterface->CreateSoundBuffer(&dsbd, &pBuffer, nullptr);
 	if (FAILED(hr))
 	{
-		Logging::Log() << __FUNCTION__ << " Error: Failed to create buffer! file: " << filePath << " hr: " << (DSERR)hr;
+		Logging::Log() << __FUNCTION__ << " Error: Failed to create buffer! ID: " << BufferID << " hr: " << (DSERR)hr;
 		return hr;
 	}
-	*ppDSBuffer = new m_IDirectSoundBuffer8((IDirectSoundBuffer8*)pBuffer);
+	pDirectSoundWavBuffer[BufferID] = new m_IDirectSoundBuffer8((IDirectSoundBuffer8*)pBuffer);
 
-	// Lock the buffer and copy the audio data
-	LPVOID pData = nullptr;
-	DWORD dataSize = dsbd.dwBufferBytes;
-	hr = (*ppDSBuffer)->Lock(0, dataSize, &pData, &dataSize, nullptr, nullptr, DSBLOCK_ENTIREBUFFER);
-	if (FAILED(hr))
-	{
-		Logging::Log() << __FUNCTION__ << " Error: Failed to lock buffer! file: " << filePath << " hr: " << (DSERR)hr;
-		return hr;
-	}
-	memcpy(pData, AudioBuffer.data(), dataSize);
-	(*ppDSBuffer)->Unlock(pData, dataSize, nullptr, 0);
+	*ppDSBuffer = pDirectSoundWavBuffer[BufferID];
 
 	return hr;
+}
+
+void m_IDirectSound8::ReleaseWavSoundBuffer(DWORD BufferID)
+{
+	if (pDirectSoundWavBuffer[BufferID])
+	{
+		// Mute volume
+		pDirectSoundWavBuffer[BufferID]->SetVolume(0);
+
+		// Release buffer
+		UINT ref = pDirectSoundWavBuffer[BufferID]->Release();
+		if (ref != 0)
+		{
+			Logging::Log() << __FUNCTION__ << " Error: there is still a reference to the sound buffer " << ref;
+		}
+		pDirectSoundWavBuffer[BufferID] = nullptr;
+	}
 }
 
 HRESULT m_IDirectSound8::ParseWavFile(const char* filePath, DSBUFFERDESC& dsbd, WAVEFORMATEX& waveFormat, std::vector<char>& AudioBuffer)
@@ -392,15 +411,13 @@ HRESULT m_IDirectSound8::ParseWavFile(const char* filePath, DSBUFFERDESC& dsbd, 
 			break;
 		}
 
-		// Settings the buffer desc
-		dsbd = {};
-		dsbd.dwSize = sizeof(DSBUFFERDESC);
-		dsbd.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY | DSBCAPS_CTRLPAN | DSBCAPS_CTRLPOSITIONNOTIFY;
+		// Set the buffer desc
 		dsbd.dwBufferBytes = dataSize;
 		dsbd.lpwfxFormat = &waveFormat;
 
 		// Set hr to success
 		hr = DS_OK;
+
 	} while (false);
 
 	// Close and exit
@@ -408,7 +425,7 @@ HRESULT m_IDirectSound8::ParseWavFile(const char* filePath, DSBUFFERDESC& dsbd, 
 	return hr;
 }
 
-HRESULT m_IDirectSound8::PlayWavFile(const char* filePath, DWORD BifferID)
+HRESULT m_IDirectSound8::PlayWavFile(const char* filePath, DWORD BufferID, bool useSfxVolume)
 {
 	if (!filePath)
 	{
@@ -416,11 +433,7 @@ HRESULT m_IDirectSound8::PlayWavFile(const char* filePath, DWORD BifferID)
 		return DSERR_INVALIDPARAM;
 	}
 
-	if (BifferID + 1 > MaxBuffers)
-	{
-		Logging::Log() << __FUNCTION__ << " Error: invalid buffer ID!";
-		return DSERR_INVALIDPARAM;
-	}
+	ScopedCriticalSection ThreatLock(&dscs);
 
 	if (!pCurrentDirectSound)
 	{
@@ -428,92 +441,75 @@ HRESULT m_IDirectSound8::PlayWavFile(const char* filePath, DWORD BifferID)
 		return DSERR_DS8_REQUIRED;
 	}
 
-	EnterCriticalSection(&dscs);
+	// Setting the buffer desc
+	DSBUFFERDESC dsbd = {};
+	dsbd = {};
+	dsbd.dwSize = sizeof(DSBUFFERDESC);
+	dsbd.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY | DSBCAPS_CTRLPAN | DSBCAPS_CTRLPOSITIONNOTIFY;
 
-	// Release all buffers that are not playing
-	for (DWORD x = 0; x < MaxBuffers; x++)
+	// Buffer variables
+	WAVEFORMATEX waveFormat = {};
+	std::vector<char> AudioBuffer;
+
+	// Parse WAV files
+	HRESULT hr = ParseWavFile(filePath, dsbd, waveFormat, AudioBuffer);
+	if (FAILED(hr))
 	{
-		if (pDirectSoundWavBuffer[x])
-		{
-			DWORD Status = 0;
-			if (SUCCEEDED(pDirectSoundWavBuffer[x]->GetStatus(&Status)) && !(Status & DSBSTATUS_PLAYING))
-			{
-				ReleaseSoundBuffer(x);
-			}
-		}
+		Logging::Log() << __FUNCTION__ << " Error: failed to load WAV! file: " << filePath << " hr: " << (DSERR)hr;
+		return hr;
 	}
 
-	// Release current buffer
-	ReleaseSoundBuffer(BifferID);
-
-	HRESULT hr = pCurrentDirectSound->CreateWAVSoundBuffer(filePath, &pDirectSoundWavBuffer[BifferID]);
-
-	if (SUCCEEDED(hr))
+	// Create sound buffer
+	m_IDirectSoundBuffer8* pBuffer = nullptr;
+	hr = pCurrentDirectSound->CreateWavSoundBuffer(BufferID, dsbd, &pBuffer);
+	if (FAILED(hr))
 	{
-		// Get the volume level
-		LONG SFXVolume = DSBVOLUME_MAX;
+		Logging::Log() << __FUNCTION__ << " Error: Failed to create buffer! file: " << filePath << " hr: " << (DSERR)hr;
+		return hr;
+	}
+
+	// Lock the buffer and copy the audio data
+	LPVOID pData = nullptr;
+	DWORD dataSize = dsbd.dwBufferBytes;
+
+	hr = pBuffer->Lock(0, dataSize, &pData, &dataSize, nullptr, nullptr, DSBLOCK_ENTIREBUFFER);
+	if (FAILED(hr))
+	{
+		Logging::Log() << __FUNCTION__ << " Error: Failed to lock buffer! file: " << filePath << " hr: " << (DSERR)hr;
+		return hr;
+	}
+
+	memcpy(pData, AudioBuffer.data(), dataSize);
+
+	pBuffer->Unlock(pData, dataSize, nullptr, 0);
+
+	// Get the volume level
+	LONG Volume = DSBVOLUME_MAX;
+	if (useSfxVolume)
+	{
 		BYTE SFXVolumeLevel = GetSFXVolume();
 		if (SFXVolumeLevel < 16)
 		{
-			SFXVolume = VolumeArray[SFXVolumeLevel];
+			Volume = VolumeArray[SFXVolumeLevel];
 		}
-
-		// Set the volume
-		pDirectSoundWavBuffer[BifferID]->SetVolume(SFXVolume);
-
-		// Play the loaded WAV file
-		pDirectSoundWavBuffer[BifferID]->Play(0, 0, 0);
-
-		Logging::LogDebug() << __FUNCTION__ << " Playing sound: " << filePath;
 	}
 
-	LeaveCriticalSection(&dscs);
+	// Set the volume
+	pBuffer->SetVolume(Volume);
+
+	// Play the loaded WAV file
+	hr = pBuffer->Play(0, 0, 0);
+	if (FAILED(hr))
+	{
+		Logging::Log() << __FUNCTION__ << " Error: Play failed! file: " << filePath << " hr: " << (DSERR)hr;
+		return hr;
+	}
+
+	Logging::LogDebug() << __FUNCTION__ << " Playing sound: " << filePath;
 
 	return hr;
 }
 
-HRESULT m_IDirectSound8::StopWavFile(DWORD BifferID)
-{
-	if (BifferID + 1 > MaxBuffers)
-	{
-		Logging::Log() << __FUNCTION__ << " Error: invalid buffer ID!";
-		return DSERR_INVALIDPARAM;
-	}
-
-	if (!pCurrentDirectSound)
-	{
-		Logging::Log() << __FUNCTION__ << " Error: current DriectSound8 not setup!";
-		return DSERR_DS8_REQUIRED;
-	}
-
-	if (pDirectSoundWavBuffer[BifferID])
-	{
-		EnterCriticalSection(&dscs);
-
-		ReleaseSoundBuffer(BifferID);
-
-		LeaveCriticalSection(&dscs);
-	}
-
-	return DS_OK;
-}
-
-void m_IDirectSound8::ReleaseSoundBuffer(DWORD BifferID)
-{
-	if (pDirectSoundWavBuffer[BifferID])
-	{
-		// Mute volume
-		pDirectSoundWavBuffer[BifferID]->SetVolume(0);
-
-		// Release buffer
-		UINT ref = pDirectSoundWavBuffer[BifferID]->Release();
-		if (ref != 0)
-		{
-			Logging::Log() << __FUNCTION__ << " Error: there is still a reference to the sound buffer " << ref;
-		}
-		pDirectSoundWavBuffer[BifferID] = nullptr;
-	}
-}
 HRESULT m_IDirectSound8::PlayWavMemory(const WAVEFORMATEX* waveFormat, const BYTE* audioData, DWORD audioSize, DWORD BufferID, bool useSfxVolume)
 {
 	if (!waveFormat || !audioData || audioSize == 0)
@@ -522,11 +518,7 @@ HRESULT m_IDirectSound8::PlayWavMemory(const WAVEFORMATEX* waveFormat, const BYT
 		return DSERR_INVALIDPARAM;
 	}
 
-	if (BufferID + 1 > MaxBuffers)
-	{
-		Logging::Log() << __FUNCTION__ << " Error: invalid buffer ID!";
-		return DSERR_INVALIDPARAM;
-	}
+	ScopedCriticalSection ThreatLock(&dscs);
 
 	if (!pCurrentDirectSound)
 	{
@@ -534,52 +526,32 @@ HRESULT m_IDirectSound8::PlayWavMemory(const WAVEFORMATEX* waveFormat, const BYT
 		return DSERR_DS8_REQUIRED;
 	}
 
-	EnterCriticalSection(&dscs);
-
-	// Release all buffers that are not playing
-	for (DWORD x = 0; x < MaxBuffers; x++)
-	{
-		if (pDirectSoundWavBuffer[x])
-		{
-			DWORD Status = 0;
-			if (SUCCEEDED(pDirectSoundWavBuffer[x]->GetStatus(&Status)) && !(Status & DSBSTATUS_PLAYING))
-			{
-				ReleaseSoundBuffer(x);
-			}
-		}
-	}
-
-	// Release current buffer
-	ReleaseSoundBuffer(BufferID);
-
+	// Setting the buffer desc
 	DSBUFFERDESC dsbd = {};
 	dsbd.dwSize = sizeof(DSBUFFERDESC);
 	dsbd.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY | DSBCAPS_CTRLPAN | DSBCAPS_CTRLPOSITIONNOTIFY;
 	dsbd.dwBufferBytes = audioSize;
 	dsbd.lpwfxFormat = const_cast<WAVEFORMATEX*>(waveFormat);
 
-	LPDIRECTSOUNDBUFFER pBuffer = nullptr;
-	HRESULT hr = pCurrentDirectSound->CreateSoundBuffer(&dsbd, &pBuffer, nullptr);
-	if (FAILED(hr) || !pBuffer)
+	// Create sound buffer
+	m_IDirectSoundBuffer8* pBuffer = nullptr;
+	HRESULT hr = pCurrentDirectSound->CreateWavSoundBuffer(BufferID, dsbd, &pBuffer);
+	if (FAILED(hr))
 	{
-		LeaveCriticalSection(&dscs);
-		Logging::Log() << __FUNCTION__ << " Error: CreateSoundBuffer failed!";
-		return FAILED(hr) ? hr : DSERR_GENERIC;
+		Logging::Log() << __FUNCTION__ << " Error: Failed to create buffer! ID: " << BufferID << " hr: " << (DSERR)hr;
+		return hr;
 	}
 
-	m_IDirectSoundBuffer8* pWrappedBuffer = (m_IDirectSoundBuffer8*)pBuffer;
-
+	// Lock the buffer and copy the audio data
 	LPVOID pData1 = nullptr;
 	DWORD dataSize1 = 0;
 	LPVOID pData2 = nullptr;
 	DWORD dataSize2 = 0;
 
-	hr = pWrappedBuffer->Lock(0, audioSize, &pData1, &dataSize1, &pData2, &dataSize2, DSBLOCK_ENTIREBUFFER);
+	hr = pBuffer->Lock(0, audioSize, &pData1, &dataSize1, &pData2, &dataSize2, DSBLOCK_ENTIREBUFFER);
 	if (FAILED(hr))
 	{
-		pWrappedBuffer->Release();
-		LeaveCriticalSection(&dscs);
-		Logging::Log() << __FUNCTION__ << " Error: Lock failed!";
+		Logging::Log() << __FUNCTION__ << " Error: Lock failed! ID: " << BufferID << " hr: " << (DSERR)hr;
 		return hr;
 	}
 
@@ -592,8 +564,9 @@ HRESULT m_IDirectSound8::PlayWavMemory(const WAVEFORMATEX* waveFormat, const BYT
 		memcpy(pData2, audioData + dataSize1, dataSize2);
 	}
 
-	pWrappedBuffer->Unlock(pData1, dataSize1, pData2, dataSize2);
+	pBuffer->Unlock(pData1, dataSize1, pData2, dataSize2);
 
+	// Get the volume level
 	LONG Volume = DSBVOLUME_MAX;
 	if (useSfxVolume)
 	{
@@ -604,21 +577,42 @@ HRESULT m_IDirectSound8::PlayWavMemory(const WAVEFORMATEX* waveFormat, const BYT
 		}
 	}
 
-	pWrappedBuffer->SetVolume(Volume);
+	// Set the volume
+	pBuffer->SetVolume(Volume);
 
-	hr = pWrappedBuffer->Play(0, 0, 0);
+	// Play the loaded WAV file
+	hr = pBuffer->Play(0, 0, 0);
 	if (FAILED(hr))
 	{
-		pWrappedBuffer->Release();
-		LeaveCriticalSection(&dscs);
-		Logging::Log() << __FUNCTION__ << " Error: Play failed!";
+		Logging::Log() << __FUNCTION__ << " Error: Play failed! ID: " << BufferID << " hr: " << (DSERR)hr;
 		return hr;
 	}
 
-	pDirectSoundWavBuffer[BufferID] = pWrappedBuffer;
+	Logging::LogDebug() << __FUNCTION__ << " Playing in-memory WAV buffer. ID: " << BufferID;
 
-	Logging::LogDebug() << __FUNCTION__ << " Playing in-memory WAV buffer.";
-
-	LeaveCriticalSection(&dscs);
 	return hr;
+}
+
+HRESULT m_IDirectSound8::StopWavSoundBuffer(DWORD BufferID)
+{
+	if (BufferID + 1 > MaxBuffers)
+	{
+		Logging::Log() << __FUNCTION__ << " Error: invalid buffer ID!";
+		return DSERR_INVALIDPARAM;
+	}
+
+	ScopedCriticalSection ThreatLock(&dscs);
+
+	if (!pCurrentDirectSound)
+	{
+		Logging::Log() << __FUNCTION__ << " Error: current DriectSound8 not setup!";
+		return DSERR_DS8_REQUIRED;
+	}
+
+	if (pDirectSoundWavBuffer[BufferID])
+	{
+		pCurrentDirectSound->ReleaseWavSoundBuffer(BufferID);
+	}
+
+	return DS_OK;
 }

--- a/Wrappers/dsound/IDirectSound8.h
+++ b/Wrappers/dsound/IDirectSound8.h
@@ -55,4 +55,5 @@ public:
 	static HRESULT PlayWavFile(const char* filePath, DWORD BifferID);
 	static HRESULT StopWavFile(DWORD BifferID);
 	static void ReleaseSoundBuffer(DWORD BifferID);
+	static HRESULT PlayWavMemory(const WAVEFORMATEX* wf, const BYTE* audioData, DWORD audioSize, DWORD BufferID, bool useSfxVolume);
 };

--- a/Wrappers/dsound/IDirectSound8.h
+++ b/Wrappers/dsound/IDirectSound8.h
@@ -48,12 +48,12 @@ public:
 	STDMETHOD(VerifyCertification)(THIS_ _Out_ LPDWORD pdwCertified);
 
 	// Helper functions
-	HRESULT CreateWAVSoundBuffer(const char* filePath, m_IDirectSoundBuffer8** ppDSBuffer);
+	HRESULT CreateWavSoundBuffer(DWORD BufferID, DSBUFFERDESC& dsbd, m_IDirectSoundBuffer8** ppDSBuffer);
+	void ReleaseWavSoundBuffer(DWORD BufferID);
 
-	// static functions
+	// Static functions
 	static HRESULT ParseWavFile(const char* filePath, DSBUFFERDESC& dsbd, WAVEFORMATEX& waveFormat, std::vector<char>& AudioBuffer);
-	static HRESULT PlayWavFile(const char* filePath, DWORD BifferID);
-	static HRESULT StopWavFile(DWORD BifferID);
-	static void ReleaseSoundBuffer(DWORD BifferID);
+	static HRESULT PlayWavFile(const char* filePath, DWORD BufferID, bool useSfxVolume);
 	static HRESULT PlayWavMemory(const WAVEFORMATEX* wf, const BYTE* audioData, DWORD audioSize, DWORD BufferID, bool useSfxVolume);
+	static HRESULT StopWavSoundBuffer(DWORD BufferID);
 };

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -359,6 +359,7 @@ copy /Y "$(ProjectDir)Resources\SH2EEsetup.exe" "$(TargetDir)" &gt;nul</Command>
     <ClInclude Include="Common\LoadModules.h" />
     <ClInclude Include="Common\md5.h" />
     <ClInclude Include="Common\ModelGLTF.h" />
+    <ClInclude Include="Common\ScopeGuard.h" />
     <ClInclude Include="Common\Settings.h" />
     <ClInclude Include="Common\Unicode.h" />
     <ClInclude Include="Common\Utils.h" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -814,6 +814,9 @@
     <ClInclude Include="External\reshade\source\effect_token.hpp">
       <Filter>External\ReShadeFX</Filter>
     </ClInclude>
+    <ClInclude Include="Common\ScopeGuard.h">
+      <Filter>Common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resources\sh2-enhce.rc">


### PR DESCRIPTION
- Uses the existing DirectSound device from the project.
- Creates buffers using the project's wrapper system.
- Registers the buffer so StopWavFile can stop playback correctly.
- Allows bypassing SFX volume through a parameter, since this audio is not intended to behave like a regular SFX.

@elishacloud  Thank you for the suggestions and guidance.

I followed the approach of using the project's existing DirectSound wrapper and buffer system. The only part that required a slightly different solution was the playback itself. In this case it wasn't possible to use PlayWavFile directly, since it expects a WAV file from disk, while this feature reads WAV data from inside the AFS archive and plays specific time ranges from it.

Because of that, I added PlayWavMemory so the audio can be played directly from the PCM data already loaded in memory.

If I misunderstood anything or if there is a better way to integrate this with the existing code, please let me know.