### PR TITLE
Updates to enhanced water shader

### DIFF
--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -199,12 +199,12 @@
 	visit(SmallFontWidth, 16) \
 	visit(SpaceSize, 7) \
 	visit(SpeedrunMode, 0) \
-	visit(water_uv_mode_cemetery, 0) \
-	visit(water_uv_mode_lake, 0) \
-	visit(water_alpha_cemetery, 40) \
-	visit(water_alpha_lake, 70) \
-	visit(water_rgb_cemetery, 50) \
-	visit(water_rgb_lake, 24)
+	visit(water_uv_mode_cemetery, 1) \
+	visit(water_uv_mode_lake, 1) \
+	visit(water_alpha_cemetery, 255) \
+	visit(water_alpha_lake, 255) \
+	visit(water_rgb_cemetery, 255) \
+	visit(water_rgb_lake, 255)
 
 #define VISIT_FLOAT_SETTINGS(visit) \
 	visit(fog_layer1_x1, 0.250f) \
@@ -216,22 +216,22 @@
 	visit(fog_layer2_density_mult, 1.4f) \
 	visit(LimitPerFrameFPS, 59.997f) \
 	visit(water_spec_mult_apt_staircase, 0.035f) \
-	visit(water_spec_mult_cemetery, 0.15f) \
+	visit(water_spec_mult_cemetery, 0.1f) \
 	visit(water_spec_mult_hotel, 0.05f) \
 	visit(water_spec_mult_labyrinth, 0.017f) \
-	visit(water_spec_mult_lake, 0.15f) \
+	visit(water_spec_mult_lake, 0.07f) \
 	visit(water_spec_mult_strange_area, 0.017f) \
 	visit(water_spec_uv_mult_cemetery, 0.85f) \
 	visit(water_spec_uv_mult_hotel, 0.45f) \
-	visit(water_spec_uv_mult_lake, 0.85f) \
+	visit(water_spec_uv_mult_lake, 1.0f) \
 	visit(water_uv_rot_radius_cemetery, 100.0f) \
 	visit(water_uv_rot_radius_lake, 100.0f) \
 	visit(water_uv_rot_speed_cemetery, 0.1f) \
 	visit(water_uv_rot_speed_lake, 0.1f) \
-	visit(water_uv_scroll_u_speed_cemetery, 0.02f) \
-	visit(water_uv_scroll_u_speed_lake, 0.0f) \
-	visit(water_uv_scroll_v_speed_cemetery, -0.02f) \
-	visit(water_uv_scroll_v_speed_lake, -0.02f) \
+	visit(water_uv_scroll_u_speed_cemetery, -0.01f) \
+	visit(water_uv_scroll_u_speed_lake, -0.04f) \
+	visit(water_uv_scroll_v_speed_cemetery, 0.03f) \
+	visit(water_uv_scroll_v_speed_lake, 0.02f) \
 	visit(closet_replacement_model_hide_time, 359.5f) \
 	visit(closet_replacement_model_reveal_time, 1695.0f)
 

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -201,6 +201,7 @@
 	visit(SpeedrunMode, 0) \
 	visit(water_uv_mode_cemetery, 1) \
 	visit(water_uv_mode_lake, 1) \
+	visit(water_uv_mode_lake_rebirth, 1) \
 	visit(water_alpha_cemetery, 255) \
 	visit(water_alpha_lake, 255) \
 	visit(water_rgb_cemetery, 255) \
@@ -226,12 +227,16 @@
 	visit(water_spec_uv_mult_lake, 1.0f) \
 	visit(water_uv_rot_radius_cemetery, 100.0f) \
 	visit(water_uv_rot_radius_lake, 100.0f) \
+	visit(water_uv_rot_radius_lake_rebirth, 100.0f) \
 	visit(water_uv_rot_speed_cemetery, 0.1f) \
 	visit(water_uv_rot_speed_lake, 0.1f) \
+	visit(water_uv_rot_speed_lake_rebirth, 0.1f) \
 	visit(water_uv_scroll_u_speed_cemetery, -0.01f) \
 	visit(water_uv_scroll_u_speed_lake, -0.04f) \
+	visit(water_uv_scroll_u_speed_lake_rebirth, -0.04f) \
 	visit(water_uv_scroll_v_speed_cemetery, 0.03f) \
 	visit(water_uv_scroll_v_speed_lake, 0.02f) \
+	visit(water_uv_scroll_v_speed_lake_rebirth, 0.02f) \
 	visit(closet_replacement_model_hide_time, 359.5f) \
 	visit(closet_replacement_model_reveal_time, 1695.0f)
 
@@ -331,14 +336,19 @@
 	visit(water_spec_uv_mult_lake) \
 	visit(water_uv_mode_cemetery) \
 	visit(water_uv_mode_lake) \
+	visit(water_uv_mode_lake_rebirth) \
 	visit(water_uv_rot_radius_cemetery) \
 	visit(water_uv_rot_radius_lake) \
+	visit(water_uv_rot_radius_lake_rebirth) \
 	visit(water_uv_rot_speed_cemetery) \
 	visit(water_uv_rot_speed_lake) \
+	visit(water_uv_rot_speed_lake_rebirth) \
 	visit(water_uv_scroll_u_speed_cemetery) \
 	visit(water_uv_scroll_u_speed_lake) \
+	visit(water_uv_scroll_u_speed_lake_rebirth) \
 	visit(water_uv_scroll_v_speed_cemetery) \
 	visit(water_uv_scroll_v_speed_lake) \
+	visit(water_uv_scroll_v_speed_lake_rebirth) \
 	visit(closet_replacement_model_hide_time) \
 	visit(closet_replacement_model_reveal_time) \
 	visit(WrapperType)

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -222,9 +222,11 @@
 	visit(water_spec_mult_labyrinth, 0.017f) \
 	visit(water_spec_mult_lake, 0.07f) \
 	visit(water_spec_mult_strange_area, 0.017f) \
+	visit(water_spec_mult_town_east, 0.07f) \
 	visit(water_spec_uv_mult_cemetery, 0.85f) \
 	visit(water_spec_uv_mult_hotel, 0.45f) \
 	visit(water_spec_uv_mult_lake, 1.0f) \
+	visit(water_spec_uv_mult_town_east, 1.0f) \
 	visit(water_uv_rot_radius_cemetery, 100.0f) \
 	visit(water_uv_rot_radius_lake, 100.0f) \
 	visit(water_uv_rot_radius_lake_rebirth, 100.0f) \
@@ -331,9 +333,11 @@
 	visit(water_spec_mult_labyrinth) \
 	visit(water_spec_mult_lake) \
 	visit(water_spec_mult_strange_area) \
+	visit(water_spec_mult_town_east) \
 	visit(water_spec_uv_mult_cemetery) \
 	visit(water_spec_uv_mult_hotel) \
 	visit(water_spec_uv_mult_lake) \
+	visit(water_spec_uv_mult_town_east) \
 	visit(water_uv_mode_cemetery) \
 	visit(water_uv_mode_lake) \
 	visit(water_uv_mode_lake_rebirth) \

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -137,6 +137,7 @@
 	visit(Room312ShadowFix, true) \
 	visit(RoomLightingFix, true) \
 	visit(RowboatAnimationFix, true) \
+	visit(RowboatSpawnFix, true) \
 	visit(SetBlackPillarBoxes, true) \
 	visit(SetSixtyFPS, true) \
 	visit(SetSwapEffectUpgradeShim, false) \
@@ -290,6 +291,7 @@
 	visit(QuickSaveCancelFix) \
 	visit(ResX) \
 	visit(ResY) \
+	visit(RowboatSpawnFix) \
 	visit(ScaleWindowedResolution)\
 	visit(ScreenMode) \
 	visit(SetSwapEffectUpgradeShim) \

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -198,7 +198,9 @@
 	visit(SmallFontHeight, 24) \
 	visit(SmallFontWidth, 16) \
 	visit(SpaceSize, 7) \
-	visit(SpeedrunMode, 0)
+	visit(SpeedrunMode, 0) \
+	visit(water_uv_mode_cemetery, 0) \
+	visit(water_uv_mode_lake, 0)
 
 #define VISIT_FLOAT_SETTINGS(visit) \
 	visit(fog_layer1_x1, 0.250f) \
@@ -218,6 +220,14 @@
 	visit(water_spec_uv_mult_cemetery, 0.85f) \
 	visit(water_spec_uv_mult_hotel, 0.45f) \
 	visit(water_spec_uv_mult_lake, 0.85f) \
+	visit(water_uv_rot_radius_cemetery, 100.0f) \
+	visit(water_uv_rot_radius_lake, 100.0f) \
+	visit(water_uv_rot_speed_cemetery, 0.1f) \
+	visit(water_uv_rot_speed_lake, 0.1f) \
+	visit(water_uv_scroll_u_speed_cemetery, 0.02f) \
+	visit(water_uv_scroll_u_speed_lake, 0.0f) \
+	visit(water_uv_scroll_v_speed_cemetery, -0.02f) \
+	visit(water_uv_scroll_v_speed_lake, -0.02f) \
 	visit(closet_replacement_model_hide_time, 359.5f) \
 	visit(closet_replacement_model_reveal_time, 1695.0f)
 
@@ -311,6 +321,16 @@
 	visit(water_spec_uv_mult_cemetery) \
 	visit(water_spec_uv_mult_hotel) \
 	visit(water_spec_uv_mult_lake) \
+	visit(water_uv_mode_cemetery) \
+	visit(water_uv_mode_lake) \
+	visit(water_uv_rot_radius_cemetery) \
+	visit(water_uv_rot_radius_lake) \
+	visit(water_uv_rot_speed_cemetery) \
+	visit(water_uv_rot_speed_lake) \
+	visit(water_uv_scroll_u_speed_cemetery) \
+	visit(water_uv_scroll_u_speed_lake) \
+	visit(water_uv_scroll_v_speed_cemetery) \
+	visit(water_uv_scroll_v_speed_lake) \
 	visit(closet_replacement_model_hide_time) \
 	visit(closet_replacement_model_reveal_time) \
 	visit(WrapperType)

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -210,14 +210,16 @@
 	visit(fog_layer2_density_mult, 1.4f) \
 	visit(LimitPerFrameFPS, 59.997f) \
 	visit(water_spec_mult_apt_staircase, 0.035f) \
-	visit(water_spec_mult_strange_area, 0.017f) \
-	visit(water_spec_mult_labyrinth, 0.017f) \
+	visit(water_spec_mult_cemetery, 0.15f) \
 	visit(water_spec_mult_hotel, 0.05f) \
-	visit(water_spec_uv_mult_hotel, 0.45f) \
-    visit(water_spec_mult_cemetery, 0.15f) \
+	visit(water_spec_mult_labyrinth, 0.017f) \
+	visit(water_spec_mult_lake, 0.15f) \
+	visit(water_spec_mult_strange_area, 0.017f) \
 	visit(water_spec_uv_mult_cemetery, 0.85f) \
-    visit(closet_replacement_model_hide_time, 359.5f) \
-    visit(closet_replacement_model_reveal_time, 1695.0f)
+	visit(water_spec_uv_mult_hotel, 0.45f) \
+	visit(water_spec_uv_mult_lake, 0.85f) \
+	visit(closet_replacement_model_hide_time, 359.5f) \
+	visit(closet_replacement_model_reveal_time, 1695.0f)
 
 #define VISIT_STR_SETTINGS(visit) \
 	visit(CustomModFolder, "") \
@@ -301,14 +303,16 @@
 	visit(SmokeFogFix) \
 	visit(SpaceSize) \
 	visit(water_spec_mult_apt_staircase) \
-	visit(water_spec_mult_strange_area) \
-	visit(water_spec_mult_labyrinth) \
+	visit(water_spec_mult_cemetery) \
 	visit(water_spec_mult_hotel) \
-	visit(water_spec_uv_mult_hotel) \
-    visit(water_spec_mult_cemetery) \
+	visit(water_spec_mult_labyrinth) \
+	visit(water_spec_mult_lake) \
+	visit(water_spec_mult_strange_area) \
 	visit(water_spec_uv_mult_cemetery) \
-    visit(closet_replacement_model_hide_time) \
-    visit(closet_replacement_model_reveal_time) \
+	visit(water_spec_uv_mult_hotel) \
+	visit(water_spec_uv_mult_lake) \
+	visit(closet_replacement_model_hide_time) \
+	visit(closet_replacement_model_reveal_time) \
 	visit(WrapperType)
 
 typedef enum _SCREENMODE {

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -200,7 +200,11 @@
 	visit(SpaceSize, 7) \
 	visit(SpeedrunMode, 0) \
 	visit(water_uv_mode_cemetery, 0) \
-	visit(water_uv_mode_lake, 0)
+	visit(water_uv_mode_lake, 0) \
+	visit(water_alpha_cemetery, 40) \
+	visit(water_alpha_lake, 70) \
+	visit(water_rgb_cemetery, 50) \
+	visit(water_rgb_lake, 24)
 
 #define VISIT_FLOAT_SETTINGS(visit) \
 	visit(fog_layer1_x1, 0.250f) \
@@ -312,6 +316,10 @@
 	visit(SmallFontWidth) \
 	visit(SmokeFogFix) \
 	visit(SpaceSize) \
+	visit(water_alpha_cemetery) \
+	visit(water_alpha_lake) \
+	visit(water_rgb_cemetery) \
+	visit(water_rgb_lake) \
 	visit(water_spec_mult_apt_staircase) \
 	visit(water_spec_mult_cemetery) \
 	visit(water_spec_mult_hotel) \

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -199,9 +199,6 @@
 	visit(SmallFontWidth, 16) \
 	visit(SpaceSize, 7) \
 	visit(SpeedrunMode, 0) \
-	visit(water_uv_mode_cemetery, 1) \
-	visit(water_uv_mode_lake, 1) \
-	visit(water_uv_mode_lake_rebirth, 1) \
 	visit(water_alpha_cemetery, 255) \
 	visit(water_alpha_lake, 255) \
 	visit(water_rgb_cemetery, 255) \
@@ -227,12 +224,6 @@
 	visit(water_spec_uv_mult_hotel, 0.45f) \
 	visit(water_spec_uv_mult_lake, 1.0f) \
 	visit(water_spec_uv_mult_town_east, 1.0f) \
-	visit(water_uv_rot_radius_cemetery, 100.0f) \
-	visit(water_uv_rot_radius_lake, 100.0f) \
-	visit(water_uv_rot_radius_lake_rebirth, 100.0f) \
-	visit(water_uv_rot_speed_cemetery, 0.1f) \
-	visit(water_uv_rot_speed_lake, 0.1f) \
-	visit(water_uv_rot_speed_lake_rebirth, 0.1f) \
 	visit(water_uv_scroll_u_speed_cemetery, -0.01f) \
 	visit(water_uv_scroll_u_speed_lake, -0.04f) \
 	visit(water_uv_scroll_u_speed_lake_rebirth, -0.03f) \
@@ -341,12 +332,6 @@
 	visit(water_uv_mode_cemetery) \
 	visit(water_uv_mode_lake) \
 	visit(water_uv_mode_lake_rebirth) \
-	visit(water_uv_rot_radius_cemetery) \
-	visit(water_uv_rot_radius_lake) \
-	visit(water_uv_rot_radius_lake_rebirth) \
-	visit(water_uv_rot_speed_cemetery) \
-	visit(water_uv_rot_speed_lake) \
-	visit(water_uv_rot_speed_lake_rebirth) \
 	visit(water_uv_scroll_u_speed_cemetery) \
 	visit(water_uv_scroll_u_speed_lake) \
 	visit(water_uv_scroll_u_speed_lake_rebirth) \

--- a/Common/Settings.h
+++ b/Common/Settings.h
@@ -233,10 +233,10 @@
 	visit(water_uv_rot_speed_lake_rebirth, 0.1f) \
 	visit(water_uv_scroll_u_speed_cemetery, -0.01f) \
 	visit(water_uv_scroll_u_speed_lake, -0.04f) \
-	visit(water_uv_scroll_u_speed_lake_rebirth, -0.04f) \
+	visit(water_uv_scroll_u_speed_lake_rebirth, -0.03f) \
 	visit(water_uv_scroll_v_speed_cemetery, 0.03f) \
 	visit(water_uv_scroll_v_speed_lake, 0.02f) \
-	visit(water_uv_scroll_v_speed_lake_rebirth, 0.02f) \
+	visit(water_uv_scroll_v_speed_lake_rebirth, 0.03f) \
 	visit(closet_replacement_model_hide_time, 359.5f) \
 	visit(closet_replacement_model_reveal_time, 1695.0f)
 

--- a/Patches/MapMeshToggle.cpp
+++ b/Patches/MapMeshToggle.cpp
@@ -39,6 +39,7 @@ void* jmpHotelRoom312HandlerReturnAddr1 = nullptr;
 void* jmpHotelRoom312HandlerReturnAddr2 = nullptr;
 void* jmpHospital3FHandlerReturnAddr1 = nullptr;
 void* jmpHospital3FHandlerReturnAddr2 = nullptr;
+void* jmpTownLakeReturnAddr = nullptr;
 
 bool IsGameFlagSet(int flag)
 {
@@ -114,7 +115,7 @@ __declspec(naked) void __stdcall TownLakeHandlerASM()
 	__asm
 	{
 		call TownLakeDisplayControl
-		ret
+		jmp jmpTownLakeReturnAddr
 	}
 }
 
@@ -239,7 +240,8 @@ void PatchMapMeshToggle()
 	jmpHotelRoom312HandlerReturnAddr2 = (void*)(HotelRoom312HandlerAddr + 0x89);
 	jmpHospital3FHandlerReturnAddr1 = (void*)(Hospital3FHandlerAddr + 0x09);
 	jmpHospital3FHandlerReturnAddr2 = (void*)(Hospital3FHandlerAddr + 0xC6);
-	const DWORD TownLakeInjectAddr = *(DWORD*)(TownLakeHandlerAddr) + TownLakeHandlerAddr + 0xC4;
+	jmpTownLakeReturnAddr = (void*)(*(DWORD*)(TownLakeHandlerAddr) + TownLakeHandlerAddr + 0x04);
+	const DWORD TownLakeInjectAddr = TownLakeHandlerAddr - 1;
 	HotelRoom312MemoFlagAddr = (WORD*)(*(DWORD*)Hotel3FStageDataAddr + 0x130);
 
 	shDisplayControlEntry = (void(*)(uint32_t*, uint32_t, int))(DisplayControlAddr + 0x04 + *(DWORD*)DisplayControlAddr);

--- a/Patches/MapMeshToggle.cpp
+++ b/Patches/MapMeshToggle.cpp
@@ -98,19 +98,22 @@ __declspec(naked) void __stdcall HospitalGardenHandlerASM()
 	}
 }
 
-// Shows a hint on the shipping dock that suggests using the blue gem (second time).
-void ShippingDockDisplayControl()
+
+void TownLakeDisplayControl()
 {
-	uint32_t display_list[] = { 0, 0, 0 };
+	uint32_t display_list[] = { 0, 0, 0, 0, 0 };
+	// Shows a hint on the shipping dock that suggests using the blue gem (second time).
 	shDisplayControlEntry(display_list, /*room=*/0x01, /*no=*/IsGameFlagSet(kUsedBlueGemFirstTimeGameFlag) ? 0 : -1);
+	// Shows a static water mesh during the Rebirth ending epilogue.
+	shDisplayControlEntry(display_list, /*room=*/0x0B, /*no=*/GetCutsceneID() == CS_END_REBIRTH_EPILOGUE ? 3 : -1);
 	shDisplayControlExec(display_list);
 }
 
-__declspec(naked) void __stdcall ShippingDockHandlerASM()
+__declspec(naked) void __stdcall TownLakeHandlerASM()
 {
 	__asm
 	{
-		call ShippingDockDisplayControl
+		call TownLakeDisplayControl
 		ret
 	}
 }
@@ -212,8 +215,8 @@ void PatchMapMeshToggle()
 	const BYTE HospitalGardenHandlerSearchBytes[]{ 0x83, 0xF8, 0x49, 0x0F, 0x85, 0x4E, 0x01, 0x00, 0x00 };
 	const DWORD HospitalGardenHandlerAddr = SearchAndGetAddresses(0x0058BFFC, 0x0058C8AC, 0x0058C1CC, HospitalGardenHandlerSearchBytes, sizeof(HospitalGardenHandlerSearchBytes), 0x00, __FUNCTION__);
 
-	const BYTE ShippingDockHandlerSearchBytes[]{ 0x50, 0x68, 0xF0, 0x3C, 0x00, 0x00, 0xE8 };
-	const DWORD ShippingDockHandlerAddr = SearchAndGetAddresses(0x0057ED1E, 0x0057F5CE, 0x0057EEEE, ShippingDockHandlerSearchBytes, sizeof(ShippingDockHandlerSearchBytes), 0x0F, __FUNCTION__);
+	const BYTE TownLakeHandlerSearchBytes[]{ 0x50, 0x68, 0xF0, 0x3C, 0x00, 0x00, 0xE8 };
+	const DWORD TownLakeHandlerAddr = SearchAndGetAddresses(0x0057ED1E, 0x0057F5CE, 0x0057EEEE, TownLakeHandlerSearchBytes, sizeof(TownLakeHandlerSearchBytes), 0x0F, __FUNCTION__);
 
 	const BYTE HotelRoom312HandlerSearchBytes[] { 0x3D, 0xA2, 0x00, 0x00, 0x00, 0xC7, 0x44, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00 };
 	const DWORD HotelRoom312HandlerAddr = SearchAndGetAddresses(0x00578788, 0x00579038, 0x00578958, HotelRoom312HandlerSearchBytes, sizeof(HotelRoom312HandlerSearchBytes), 0x00, __FUNCTION__);
@@ -221,7 +224,7 @@ void PatchMapMeshToggle()
 	const BYTE Hospital3FHandlerSearchBytes[]{ 0x83, 0xE8, 0x54, 0x0F, 0x84, 0xBD, 0x00, 0x00, 0x00, 0x48 };
 	const DWORD Hospital3FHandlerAddr = SearchAndGetAddresses(0x00589DE0, 0x0058A690, 0x00589FB0, Hospital3FHandlerSearchBytes, sizeof(Hospital3FHandlerSearchBytes), 0x00, __FUNCTION__);
 
-	if (!StageDataAddr || !DisplayControlAddr || !GameFlagPtr || !BlueCreek1FHandlerAddr || !HospitalGardenHandlerAddr || !ShippingDockHandlerAddr || !HotelRoom312HandlerAddr || !Hospital3FHandlerAddr)
+	if (!StageDataAddr || !DisplayControlAddr || !GameFlagPtr || !BlueCreek1FHandlerAddr || !HospitalGardenHandlerAddr || !TownLakeHandlerAddr || !HotelRoom312HandlerAddr || !Hospital3FHandlerAddr)
 	{
 		Logging::Log() << __FUNCTION__ << " Error: failed to find memory address!";
 		return;
@@ -236,7 +239,7 @@ void PatchMapMeshToggle()
 	jmpHotelRoom312HandlerReturnAddr2 = (void*)(HotelRoom312HandlerAddr + 0x89);
 	jmpHospital3FHandlerReturnAddr1 = (void*)(Hospital3FHandlerAddr + 0x09);
 	jmpHospital3FHandlerReturnAddr2 = (void*)(Hospital3FHandlerAddr + 0xC6);
-	const DWORD ShippingDockInjectAddr = *(DWORD*)(ShippingDockHandlerAddr) + ShippingDockHandlerAddr + 0xC4;
+	const DWORD TownLakeInjectAddr = *(DWORD*)(TownLakeHandlerAddr) + TownLakeHandlerAddr + 0xC4;
 	HotelRoom312MemoFlagAddr = (WORD*)(*(DWORD*)Hotel3FStageDataAddr + 0x130);
 
 	shDisplayControlEntry = (void(*)(uint32_t*, uint32_t, int))(DisplayControlAddr + 0x04 + *(DWORD*)DisplayControlAddr);
@@ -253,7 +256,7 @@ void PatchMapMeshToggle()
 	// Inject custom display control into existing stage handlers.
 	WriteJMPtoMemory((BYTE*)BlueCreek1FHandlerAddr, BlueCreek1FHandlerASM, 0x05);
 	WriteJMPtoMemory((BYTE*)HospitalGardenHandlerAddr, HospitalGardenHandlerASM, 0x09);
-	WriteJMPtoMemory((BYTE*)ShippingDockInjectAddr, ShippingDockHandlerASM, 0x05);
+	WriteJMPtoMemory((BYTE*)TownLakeInjectAddr, TownLakeHandlerASM, 0x05);
 	WriteJMPtoMemory((BYTE*)HotelRoom312HandlerAddr, HotelRoom312HandlerASM, 0x0F);
 	WriteJMPtoMemory((BYTE*)Hospital3FHandlerAddr, Hospital3FHandlerASM, 0x09);
 }

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -719,6 +719,7 @@ void PatchRemoveWeaponFromCutscene();
 void PatchRoom312ShadowFix();
 void PatchRoomLighting();
 void PatchRowboatAnimation();
+void PatchRowboatSpawn();
 void PatchSaveBGImage();
 void PatchSearchViewOptionName();
 void PatchSpeakerConfigLock();

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -807,6 +807,7 @@ float GetConditionalFlashlightBrightnessGreen();
 float GetConditionalFlashlightBrightnessBlue();
 void CheckLakeMoonSize();
 void CheckRoom312Flashlight();
+void UpdateExteriorWaterVertexColors();
 
 // Define the template function declaration
 template<typename T>

--- a/Patches/RowboatSpawn.cpp
+++ b/Patches/RowboatSpawn.cpp
@@ -1,0 +1,77 @@
+/**
+* Copyright (C) 2026 Murugo
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Patches.h"
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+
+namespace {
+    constexpr int kEnteredRowboatGameFlag = 0x17B;
+
+    BYTE* GameFlagPtr = 0;
+
+    bool IsGameFlagSet(int flag)
+    {
+        return GameFlagPtr[flag >> 3] & (1 << (flag & 0x07));
+    }
+
+    void MoveRowboatToHotelDock(BYTE* RowboatSubCharPtr)
+    {
+        if (!IsGameFlagSet(kEnteredRowboatGameFlag)) return;
+
+        float* RowboatPos = (float*)(RowboatSubCharPtr + 0x1C);
+        RowboatPos[0] = -8915.900391f;
+        RowboatPos[1] = 3690.0f;
+        RowboatPos[2] = -19412.69922f;
+
+        float* RowboatRot = (float*)(RowboatSubCharPtr + 0x2C);
+        RowboatRot[0] = 0.0f;
+        RowboatRot[1] = 3.141593f;
+        RowboatRot[2] = 0.0f;
+    }
+
+    __declspec(naked) void __stdcall RowboatSpawnASM()
+    {
+        __asm
+        {
+            mov eax, dword ptr ds : [esp]
+            call MoveRowboatToHotelDock
+            add esp, 0x4C
+            ret
+        }
+    }
+}
+
+// Spawns the rowboat at the dock outside of Lakeview Hotel when the player re-enters the area.
+void PatchRowboatSpawn()
+{
+    constexpr BYTE GameFlagSearchBytes[]{ 0x83, 0xFE, 0x01, 0x55, 0x57, 0xBD, 0x00, 0x01, 0x00, 0x00 };
+    GameFlagPtr = (BYTE*)ReadSearchedAddresses(0x0048AA9E, 0x0048AD3E, 0x0048AF4E, GameFlagSearchBytes, sizeof(GameFlagSearchBytes), 0x24, __FUNCTION__);
+
+    constexpr BYTE SpawnRowboatSearchBytes[]{ 0xC7, 0x44, 0x24, 0x38, 0xDB, 0x0F, 0xC9, 0x3F };
+    DWORD RowboatSpawnAddr = SearchAndGetAddresses(0x0057E64B, 0x0057EEFB, 0x0057E81B, SpawnRowboatSearchBytes, sizeof(SpawnRowboatSearchBytes), 0x15, __FUNCTION__);
+    if (!GameFlagPtr || !RowboatSpawnAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
+        return;
+    }
+
+    Logging::Log() << "Patching Rowboat Spawn Fix...";
+    UpdateMemoryAddress((BYTE*)(RowboatSpawnAddr - 0x83), "\x90\x90\x90\x90\x90\x90", 6);
+    WriteJMPtoMemory((BYTE*)RowboatSpawnAddr, *RowboatSpawnASM, 0x07);
+}

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -419,10 +419,10 @@ static void GetWaterConstantsByRoom(D3DXVECTOR4& specMult, D3DXVECTOR4& specUvMu
         case R_TOWN_LAKE:
         {
             dudvScale = { 0.005f, 0.005f, 0.005f, 0.005f };
-            const float specMultOverride = water_spec_mult_cemetery;
-            specMult = { specMultOverride, specMultOverride, specMultOverride, 0.0f };
-            specUvMult = { water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery };
+            specMult = { water_spec_mult_lake, water_spec_mult_lake, water_spec_mult_lake, 0.0f };
+            specUvMult = { water_spec_uv_mult_lake, water_spec_uv_mult_lake, water_spec_uv_mult_lake, water_spec_uv_mult_lake };
         }
+        break;
         // Pyramidhead submerge
         case R_APT_W_STAIRCASE_N:
             specMult = { water_spec_mult_apt_staircase, water_spec_mult_apt_staircase, water_spec_mult_apt_staircase, 0.0f };

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -585,7 +585,7 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
             Device->SetVertexShaderConstant(WATER_UVADD_VS_CB_SLOT, &uvAddition, 1);
             Device->SetVertexShaderConstant(WATER_UVMUL_VS_CB_SLOT, &specUvMult, 1);
 
-            D3DXVECTOR4 uvOffset;
+            D3DXVECTOR4 uvOffset{ 0.0f, 0.0f, 0.0f, 0.0f };
             bool forceFog = false;
             DWORD fogEnablePreserve = 0;
             DWORD fogModePreserve = 0;

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -40,6 +40,7 @@ constexpr UINT kCemeteryLeaveTextureId = 0x52F7;
 constexpr UINT kLakeRebirthTextureId = 0x1B58;
 constexpr float kWorldScale = 1.0f / 3000.0f;
 constexpr float kLakeWaterCullDistZ = -8000.0f;
+constexpr float kRebirthFogMinDistance = 15000.0f;
 
 #define WATER_VSHADER_ORIGINAL  (g_vsHandles[3])
 #define WATER_FVF               (D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1)
@@ -714,7 +715,6 @@ void PatchWaterEnhancement()
     }
     shGetTexture = (BYTE*(*)(UINT))((BYTE*)(GetTextureAddr + 0x04) + *(DWORD*)GetTextureAddr);
 
-    // Increase distance after which the lake water disappears when James leaves the hotel dock
     constexpr BYTE CullDistSearchBytes[]{ 0x83, 0xC4, 0x10, 0xEB, 0x06, 0xC7, 0x07, 0x01, 0x00, 0x00, 0x00 };
     DWORD LakeWaterCullDistZAddr = SearchAndGetAddresses(0x004D5768, 0x004D5A18, 0x004D52D8, CullDistSearchBytes, sizeof(CullDistSearchBytes), 0x11, __FUNCTION__);
     if (!LakeWaterCullDistZAddr)
@@ -723,8 +723,22 @@ void PatchWaterEnhancement()
         WaterEnhancedRender = false;
         return;
     }
+
+    constexpr BYTE RebirthFogMinDistSearchBytes[]{ 0x83, 0xF8, 0x4D, 0x75, 0x43, 0xD9, 0x05 };
+    DWORD RebirthFogMinDistAddr = ReadSearchedAddresses(0x0057E765, 0x0057F015, 0x0057E935, RebirthFogMinDistSearchBytes, sizeof(RebirthFogMinDistSearchBytes), 0x91, __FUNCTION__);
+    if (!RebirthFogMinDistAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
+        WaterEnhancedRender = false;
+        return;
+    }
+
+    // Increase distance after which the lake water disappears when James leaves the hotel dock
     const float* LakeWaterCullDistZ = &kLakeWaterCullDistZ;
     UpdateMemoryAddress((void*)LakeWaterCullDistZAddr, &LakeWaterCullDistZ, sizeof(float));
+
+    // Adjust min fog distance during Rebirth ending cutscene
+    UpdateMemoryAddress((void*)RebirthFogMinDistAddr, &kRebirthFogMinDistance, sizeof(float));
 }
 
 void CheckCemeteryWaterCulling()

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -27,6 +27,9 @@ DWORD vsDeclWater[] = {
 static DWORD* g_vsHandles = nullptr;
 static DWORD* g_cemeteryWaterPlaneCheckAddr = nullptr;
 static DWORD g_cemeteryWaterPlaneCheckValue = NULL;
+static float* g_cemeteryWaterRGB = NULL;
+static float* g_cemeteryWaterAlpha = NULL;
+static float* g_lakeWaterRGBA = NULL;
 
 BYTE*(*shGetTexture)(UINT);
 
@@ -648,6 +651,25 @@ void PatchWaterEnhancement()
         return;
     }
 
+    constexpr BYTE CemeteryWaterAlphaSearchBytes[]{ 0x89, 0x95, 0xC0, 0xFE, 0xFF, 0xFF, 0x8B, 0x45, 0x84 };
+    g_cemeteryWaterAlpha = (float*)ReadSearchedAddresses(0x004D3505, 0x004D37B5, 0x004D3075, CemeteryWaterAlphaSearchBytes, sizeof(CemeteryWaterAlphaSearchBytes), -0x10, __FUNCTION__);
+    if (!g_cemeteryWaterAlpha)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
+        WaterEnhancedRender = false;
+        return;
+    }
+    g_cemeteryWaterRGB = g_cemeteryWaterAlpha - 4;
+
+    constexpr BYTE LakeWaterAlphaSearchBytes[]{ 0x83, 0xC4, 0x0C, 0x68, 0x00, 0x00, 0x7F, 0x43, 0x6A, 0x00, 0x8D, 0x85, 0xEC, 0xFD, 0xFF, 0xFF };
+    g_lakeWaterRGBA = (float*)ReadSearchedAddresses(0x004D5075, 0x004D5325, 0x004D4BE5, LakeWaterAlphaSearchBytes, sizeof(LakeWaterAlphaSearchBytes), -0x17, __FUNCTION__);
+    if (!g_lakeWaterRGBA)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
+        WaterEnhancedRender = false;
+        return;
+    }
+
     constexpr BYTE GetTextureSearchBytes[]{ 0xB9, 0x2E, 0x00, 0x00, 0x00, 0x8B, 0xFE, 0xF3, 0xAB, 0x8B, 0x7C, 0x24, 0x10 };
     const DWORD GetTextureAddr = SearchAndGetAddresses(0x0045AE98, 0x0045B0F8, 0x0045B0F8, GetTextureSearchBytes, sizeof(GetTextureSearchBytes), 0x0F, __FUNCTION__);
     if (!GetTextureAddr)
@@ -689,4 +711,22 @@ void CheckCemeteryWaterCulling()
         UpdateMemoryAddress(g_cemeteryWaterPlaneCheckAddr, &g_cemeteryWaterPlaneCheckValue, sizeof(DWORD));
         cemeteryWaterCullingDisabled = false;
 	}
+}
+
+void UpdateExteriorWaterVertexColors()
+{
+    if (!WaterEnhancedRender)
+        return;
+
+    const DWORD roomID = GetRoomID();
+    if (g_cemeteryWaterRGB && g_cemeteryWaterAlpha && roomID == R_FOREST_CEMETERY && GetTexture(kExteriorWaterTextureId) != nullptr)
+    {
+        g_cemeteryWaterRGB[0] = g_cemeteryWaterRGB[1] = g_cemeteryWaterRGB[2] = water_rgb_cemetery;
+        *g_cemeteryWaterAlpha = water_alpha_cemetery;
+    }
+    if (g_lakeWaterRGBA && roomID == R_TOWN_LAKE && GetTexture(kExteriorWaterTextureId) != nullptr)
+    {
+        g_lakeWaterRGBA[0] = g_lakeWaterRGBA[1] = g_lakeWaterRGBA[2] = water_rgb_lake;
+        g_lakeWaterRGBA[3] = water_alpha_lake;
+    }
 }

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -254,17 +254,6 @@ IDirect3DTexture8* g_DuDvTexture = nullptr;
 IDirect3DTexture8* g_CausticsTexture = nullptr;
 
 static LARGE_INTEGER    g_QPCFreq = {};
-static uint64_t         g_StartTimeMS = 0;
-
-static uint64_t TimeGetNowMS() {
-    if (!g_QPCFreq.QuadPart) {
-        ::QueryPerformanceFrequency(&g_QPCFreq);
-    }
-
-    LARGE_INTEGER qpcNow = {};
-    ::QueryPerformanceCounter(&qpcNow);
-    return (qpcNow.QuadPart * 1000) / g_QPCFreq.QuadPart;
-}
 
 template <typename T>
 static void SafeRelease(T*& ptr) {
@@ -448,7 +437,7 @@ static void GetWaterConstantsByRoom(D3DXVECTOR4& specMult, D3DXVECTOR4& specUvMu
     }
 }
 
-HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, LPDIRECT3DDEVICE8 Device, LPDIRECT3DSURFACE8 backBufferSurface, D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void* pVertexStreamZeroData, UINT VertexStreamZeroStride) {
+HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 Device, LPDIRECT3DSURFACE8 backBufferSurface, D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void* pVertexStreamZeroData, UINT VertexStreamZeroStride) {
     DWORD colorOp0 = 0;
     Device->GetTextureStageState(0, D3DTSS_COLOROP, &colorOp0);
 
@@ -466,13 +455,7 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, LPDIRECT3DDEVICE8 Devic
             }
             LoadWaterUtilityTextures(Device);
 
-            if (!g_StartTimeMS) {
-                g_StartTimeMS = TimeGetNowMS();
-            }
-            const uint64_t timeNow = TimeGetNowMS();
-            const uint64_t timeDelta = timeNow - g_StartTimeMS;
-
-            const float fraction = GetFracPart(static_cast<float>(timeDelta) * 0.00005f);
+            const float fraction = GetFracPart(static_cast<float>(inGameTimerMs) * 0.00005f);
             const D3DXVECTOR4 uvAddition(fraction, fraction, fraction, fraction);
 
             D3DXVECTOR4 specMult;

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -30,7 +30,9 @@ static DWORD g_cemeteryWaterPlaneCheckValue = NULL;
 
 BYTE*(*shGetTexture)(UINT);
 
+constexpr double kPi = 3.141592653589793;
 constexpr UINT kExteriorWaterTextureId = 0x52F6;
+constexpr float kWorldScale = 1.0f / 3000.0f;
 constexpr float kLakeWaterCullDistZ = -8000.0f;
 
 #define WATER_VSHADER_ORIGINAL  (g_vsHandles[3])
@@ -466,6 +468,44 @@ IDirect3DBaseTexture8* GetTexture(UINT id)
     return (IDirect3DBaseTexture8*)*(DWORD*)(texturePtr + 0x8C);
 }
 
+D3DXVECTOR4 GetBaseUVOffset(DWORD roomID, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 Device) {
+    D3DXVECTOR4 uvOffset;
+
+    if (roomID != R_FOREST_CEMETERY && roomID != R_TOWN_LAKE)
+        return uvOffset;
+
+    const int mode = roomID == R_FOREST_CEMETERY ? water_uv_mode_cemetery : water_uv_mode_lake;
+    if (mode == 0) {
+        const double speed = roomID == R_FOREST_CEMETERY ? water_uv_rot_speed_cemetery : water_uv_rot_speed_lake;
+        const double radius = roomID == R_FOREST_CEMETERY ? water_uv_rot_radius_cemetery : water_uv_rot_radius_lake;
+        const double theta = static_cast<double>(inGameTimerMs) * speed * kPi / 1000.0;
+        uvOffset = {
+            static_cast<float>(std::sin(theta) * radius * kWorldScale),
+            static_cast<float>(std::cos(theta) * radius * kWorldScale),
+            0.0f,
+            0.0f
+        };
+    }
+    else {
+        const double speedU = roomID == R_FOREST_CEMETERY ? water_uv_scroll_u_speed_cemetery : water_uv_scroll_u_speed_lake;
+        const double speedV = roomID == R_FOREST_CEMETERY ? water_uv_scroll_v_speed_cemetery : water_uv_scroll_v_speed_lake;
+        uvOffset = {
+            // static_cast<float>(inGameTimerMs) * 0.00005f * speed,
+            static_cast<float>(GetFracPart(static_cast<double>(inGameTimerMs) * 0.00005 * speedU) * 20.0),
+            static_cast<float>(GetFracPart(static_cast<double>(inGameTimerMs) * 0.00005 * speedV) * 20.0),
+            0.0f,
+            0.0f
+        };
+    }
+    if (roomID == R_TOWN_LAKE) {
+        D3DXMATRIX transform;
+        Device->GetTransform(D3DTS_WORLDMATRIX(0), &transform);
+        uvOffset.x += transform.m[3][0] * kWorldScale;
+        uvOffset.y += transform.m[3][2] * kWorldScale;
+    };
+    return uvOffset;
+}
+
 HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 Device, LPDIRECT3DSURFACE8 backBufferSurface, D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void* pVertexStreamZeroData, UINT VertexStreamZeroStride) {
     DWORD colorOp0 = 0;
     Device->GetTextureStageState(0, D3DTSS_COLOROP, &colorOp0);
@@ -538,16 +578,8 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
 
             bool forceFog = false;
             if (roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) {
-                const float worldScale = 1.0f / 3000.0f;
-                D3DXVECTOR4 worldDiv = { worldScale, worldScale, worldScale, worldScale };
+                D3DXVECTOR4 worldDiv = { kWorldScale, kWorldScale, kWorldScale, kWorldScale };
                 Device->SetVertexShaderConstant(WATER_WORLD_VS_CB_SLOT, &worldDiv, 1);
-
-                if (roomID == R_TOWN_LAKE) {
-                    D3DXMATRIX transform;
-                    Device->GetTransform(D3DTS_WORLDMATRIX(0), &transform);
-                    D3DXVECTOR4 uvOffset = { transform.m[3][0] * worldScale, transform.m[3][2] * worldScale, 0.0f, 0.0f };
-                    Device->SetVertexShaderConstant(WATER_UVOFFS_VS_CB_SLOT, &uvOffset, 1);
-                }
 
                 D3DXVECTOR4 waterColour = { 0.32f, 0.32f, 0.32f, 0.35f };
                 Device->SetVertexShaderConstant(WATER_COLOUR_VS_CB_SLOT, &waterColour, 1);
@@ -565,6 +597,9 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
                 {
                     Device->SetTexture(WATER_TEXTURE_SLOT_BASE, tex);
                 }
+
+                D3DXVECTOR4 uvOffset = GetBaseUVOffset(roomID, inGameTimerMs, Device);
+                Device->SetVertexShaderConstant(WATER_UVOFFS_VS_CB_SLOT, &uvOffset, 1);
             }
 
             Device->SetPixelShaderConstant(WATER_DUDV_SCALE_PS_CB_SLOT, &dudvScale, 1u);

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -28,11 +28,15 @@ static DWORD* g_vsHandles = nullptr;
 static DWORD* g_cemeteryWaterPlaneCheckAddr = nullptr;
 static DWORD g_cemeteryWaterPlaneCheckValue = NULL;
 
+BYTE*(*shGetTexture)(UINT);
+
+constexpr UINT kExteriorWaterTextureId = 0x52F6;
 constexpr float kLakeWaterCullDistZ = -8000.0f;
 
 #define WATER_VSHADER_ORIGINAL  (g_vsHandles[3])
 #define WATER_FVF               (D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1)
 
+#define WATER_TEXTURE_SLOT_BASE             0
 #define WATER_TEXTURE_SLOT_REFRACTION       1
 #define WATER_TEXTURE_SLOT_DUDV             2
 #define WATER_TEXTURE_SLOT_CAUSTICS         3
@@ -217,36 +221,37 @@ phase
   texld r1, r3
   // sample caustics texture
   texld r3, r5
-  // blend water colour and refraction
-  lrp r0, v0.w, v0, r1
+  // tint water texture by the vertex colour (x2)
+  mul r0, r0, v0_x2
+  // blend them
+  lrp_sat r0, r0.w, r0, r1
   // add modulated caustics
-  mad_sat r0.xyz, r3, c6, r0
+  mad_sat r0, r3, c6, r0
   // fill alpha
-+ mov r0.w, c0
+  mov r0.w, c0
 */
 DWORD g_WaterPondPSBytecode[] = {
-    0xffff0104, 0x0009fffe, 0x58443344, 0x68532038,
-    0x72656461, 0x73734120, 0x6c626d65, 0x56207265,
-    0x69737265, 0x30206e6f, 0x0031392e, 0x00000051,
-    0xa00f0000, 0x3f000000, 0x3f000000, 0x3f800000,
-    0x3f800000, 0x00000051, 0xa00f0001, 0x3f000000,
-    0xbf000000, 0x3f800000, 0x3f800000, 0x00000040,
-    0x80030003, 0xbaf40002, 0x00000040, 0x80070004,
-    0xb0e40000, 0x00000040, 0x80070005, 0xb0e40003,
-    0x00000042, 0x800f0002, 0xb0e40001, 0x00000005,
-    0x800f0001, 0xa0e40004, 0x84e40002, 0x00000001,
-    0x800c0003, 0xa0e40000, 0x00000001, 0x800c0004,
-    0xa0e40000, 0x00000001, 0x800c0005, 0xa0e40000,
-    0x00000004, 0x800f0003, 0x80e40003, 0xa0e40001,
-    0xa0e40000, 0x00000002, 0x800f0003, 0x80e40003,
-    0x80e40001, 0x00000004, 0x800f0005, 0x84e40002,
-    0xa0e40005, 0x80e40005, 0x00000002, 0x800f0002,
-    0x80e40004, 0x80e40001, 0x0000fffd, 0x00000042,
-    0x800f0000, 0x80e40002, 0x00000042, 0x800f0001,
-    0x80e40003, 0x00000042, 0x800f0003, 0x80e40005,
-    0x00000001, 0x800f0000, 0x80e40001, 0x00000004,
-    0x80170000, 0x80e40003, 0xa0e40006, 0x80e40000,
-    0x40000001, 0x80080000, 0xa0e40000, 0x0000ffff
+    0xffff0104, 0x00000051, 0xa00f0000, 0x3f000000,
+    0x3f000000, 0x3f800000, 0x3f800000, 0x00000051,
+    0xa00f0001, 0x3f000000, 0xbf000000, 0x3f800000,
+    0x3f800000, 0x00000040, 0x80030003, 0xbaf40002,
+    0x00000040, 0x80070004, 0xb0e40000, 0x00000040,
+    0x80070005, 0xb0e40003, 0x00000042, 0x800f0002,
+    0xb0e40001, 0x00000005, 0x800f0001, 0xa0e40004,
+    0x84e40002, 0x00000001, 0x800c0003, 0xa0e40000,
+    0x00000001, 0x800c0004, 0xa0e40000, 0x00000001,
+    0x800c0005, 0xa0e40000, 0x00000004, 0x800f0003,
+    0x80e40003, 0xa0e40001, 0xa0e40000, 0x00000002,
+    0x800f0003, 0x80e40003, 0x80e40001, 0x00000004,
+    0x800f0005, 0x84e40002, 0xa0e40005, 0x80e40005,
+    0x00000002, 0x800f0002, 0x80e40004, 0x80e40001,
+    0x0000fffd, 0x00000042, 0x800f0000, 0x80e40002,
+    0x00000042, 0x800f0001, 0x80e40003, 0x00000042,
+    0x800f0003, 0x80e40005, 0x00000005, 0x800f0000,
+    0x80e40000, 0x97e40000, 0x00000012, 0x801f0000,
+    0x80ff0000, 0x80e40000, 0x80e40001, 0x00000004,
+    0x801f0000, 0x80e40003, 0xa0e40006, 0x80e40000,
+    0x00000001, 0x80080000, 0xa0e40000, 0x0000ffff,
 };
 
 DWORD g_WaterVSHandle = 0;
@@ -451,6 +456,16 @@ static void GetWaterConstantsByRoom(D3DXVECTOR4& specMult, D3DXVECTOR4& specUvMu
     }
 }
 
+IDirect3DBaseTexture8* GetTexture(UINT id)
+{
+    BYTE* texturePtr = shGetTexture(id);
+    if (texturePtr == nullptr)
+    {
+        return nullptr;
+    }
+    return (IDirect3DBaseTexture8*)*(DWORD*)(texturePtr + 0x8C);
+}
+
 HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 Device, LPDIRECT3DSURFACE8 backBufferSurface, D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void* pVertexStreamZeroData, UINT VertexStreamZeroStride) {
     DWORD colorOp0 = 0;
     Device->GetTextureStageState(0, D3DTSS_COLOROP, &colorOp0);
@@ -545,6 +560,11 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
                 Device->SetRenderState(D3DRS_FOGENABLE, TRUE);
                 Device->SetRenderState(D3DRS_FOGTABLEMODE, D3DFOG_LINEAR);
                 forceFog = true;
+
+                if (auto* tex = GetTexture(kExteriorWaterTextureId); tex != nullptr)
+                {
+                    Device->SetTexture(WATER_TEXTURE_SLOT_BASE, tex);
+                }
             }
 
             Device->SetPixelShaderConstant(WATER_DUDV_SCALE_PS_CB_SLOT, &dudvScale, 1u);
@@ -593,9 +613,19 @@ void PatchWaterEnhancement()
         return;
     }
 
+    constexpr BYTE GetTextureSearchBytes[]{ 0xB9, 0x2E, 0x00, 0x00, 0x00, 0x8B, 0xFE, 0xF3, 0xAB, 0x8B, 0x7C, 0x24, 0x10 };
+    const DWORD GetTextureAddr = SearchAndGetAddresses(0x0045AE98, 0x0045B0F8, 0x0045B0F8, GetTextureSearchBytes, sizeof(GetTextureSearchBytes), 0x0F, __FUNCTION__);
+    if (!GetTextureAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
+        WaterEnhancedRender = false;
+        return;
+    }
+    shGetTexture = (BYTE*(*)(UINT))((BYTE*)(GetTextureAddr + 0x04) + *(DWORD*)GetTextureAddr);
+
     // Increase distance after which the lake water disappears when James leaves the hotel dock
-    constexpr BYTE SearchBytes[]{ 0x83, 0xC4, 0x10, 0xEB, 0x06, 0xC7, 0x07, 0x01, 0x00, 0x00, 0x00 };
-    DWORD LakeWaterCullDistZAddr = SearchAndGetAddresses(0x004D5768, 0x004D5A18, 0x004D52D8, SearchBytes, sizeof(SearchBytes), 0x11, __FUNCTION__);
+    constexpr BYTE CullDistSearchBytes[]{ 0x83, 0xC4, 0x10, 0xEB, 0x06, 0xC7, 0x07, 0x01, 0x00, 0x00, 0x00 };
+    DWORD LakeWaterCullDistZAddr = SearchAndGetAddresses(0x004D5768, 0x004D5A18, 0x004D52D8, CullDistSearchBytes, sizeof(CullDistSearchBytes), 0x11, __FUNCTION__);
     if (!LakeWaterCullDistZAddr)
     {
         Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -9,6 +9,7 @@
 #include "Wrappers\d3d8\DirectX81SDK\include\d3dx8math.h"
 
 #include <cmath>
+#include <functional>
 
 #include "WaterEnhancement_dudv.h"
 #include "WaterEnhancement_caustics.h"
@@ -36,6 +37,7 @@ BYTE*(*shGetTexture)(UINT);
 constexpr double kPi = 3.141592653589793;
 constexpr UINT kExteriorWaterTextureId = 0x52F6;
 constexpr UINT kCemeteryLeaveTextureId = 0x52F7;
+constexpr UINT kLakeRebirthTextureId = 0x1B58;
 constexpr float kWorldScale = 1.0f / 3000.0f;
 constexpr float kLakeWaterCullDistZ = -8000.0f;
 
@@ -368,7 +370,7 @@ static bool CheckWaterPrimitivesCountByRoom(const UINT PrimitiveCount) {
         break;
         // Lake
         case R_TOWN_LAKE:
-            isWater = (PrimitiveCount == 68u);
+            isWater = (PrimitiveCount == 68u || PrimitiveCount == 104u);
         break;
         // Pyramidhead submerge
         case R_APT_W_STAIRCASE_N:
@@ -501,7 +503,7 @@ D3DXVECTOR4 GetBaseUVOffset(DWORD roomID, int64_t inGameTimerMs, LPDIRECT3DDEVIC
             0.0f
         };
     }
-    if (roomID == R_TOWN_LAKE) {
+    if (roomID == R_TOWN_LAKE && GetCutsceneID() != CS_END_REBIRTH_EPILOGUE) {
         D3DXMATRIX transform;
         Device->GetTransform(D3DTS_WORLDMATRIX(0), &transform);
         uvOffset.x += transform.m[3][0] * kWorldScale;
@@ -510,19 +512,20 @@ D3DXVECTOR4 GetBaseUVOffset(DWORD roomID, int64_t inGameTimerMs, LPDIRECT3DDEVIC
     return uvOffset;
 }
 
-HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 Device, LPDIRECT3DSURFACE8 backBufferSurface, D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void* pVertexStreamZeroData, UINT VertexStreamZeroStride) {
+HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 Device, LPDIRECT3DSURFACE8 backBufferSurface, UINT PrimitiveCount, std::function<HRESULT()> DrawFunc) {
     DWORD colorOp0 = 0;
     Device->GetTextureStageState(0, D3DTSS_COLOROP, &colorOp0);
 
     const DWORD roomID = GetRoomID();
 
-    if ((colorOp0 == D3DTOP_MODULATE2X || roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) && PrimitiveType == D3DPT_TRIANGLESTRIP && CheckWaterPrimitivesCountByRoom(PrimitiveCount) && VertexStreamZeroStride == 24u && pVertexStreamZeroData != nullptr) {
+    if ((colorOp0 == D3DTOP_MODULATE2X || roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) && CheckWaterPrimitivesCountByRoom(PrimitiveCount)) {
         DWORD currVS = 0u;
         Device->GetVertexShader(&currVS);
         DWORD currPS = 0u;
         Device->GetPixelShader(&currPS);
 
-        if ((currVS == WATER_VSHADER_ORIGINAL || currVS == WATER_FVF) && currPS == 0u && g_WaterVSHandle != 0u && g_WaterPSHandle != 0u) {
+        const bool waterShaderActive = g_WaterVSHandle != 0u && g_WaterPSHandle != 0u && currVS != g_WaterPondVSHandle && currVS != g_WaterVSHandle && currPS != g_WaterPondPSHandle && currPS != g_WaterPSHandle;
+        if (waterShaderActive) {
             if (needToGrabScreenForWater) {
                 WaterEnhancedGrabScreen(Device, backBufferSurface);
             }
@@ -544,7 +547,7 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
             Device->GetTexture(WATER_TEXTURE_SLOT_DUDV, &tex1);
             Device->GetTexture(WATER_TEXTURE_SLOT_CAUSTICS, &tex2);
 
-            Device->SetVertexShader((roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) ? g_WaterPondVSHandle : g_WaterVSHandle);
+            Device->SetVertexShader((roomID == R_FOREST_CEMETERY || (roomID == R_TOWN_LAKE && GetCutsceneID() != CS_END_REBIRTH_EPILOGUE)) ? g_WaterPondVSHandle : g_WaterVSHandle);
             Device->SetPixelShader((roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) ? g_WaterPondPSHandle : g_WaterPSHandle);
 
             Device->SetTexture(WATER_TEXTURE_SLOT_REFRACTION, g_ScreenCopyTexture);
@@ -581,6 +584,8 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
             Device->SetVertexShaderConstant(WATER_UVMUL_VS_CB_SLOT, &specUvMult, 1);
 
             bool forceFog = false;
+            DWORD fogEnablePreserve = 0;
+            DWORD fogModePreserve = 0;
             if (roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) {
                 D3DXVECTOR4 worldDiv = { kWorldScale, kWorldScale, kWorldScale, kWorldScale };
                 Device->SetVertexShaderConstant(WATER_WORLD_VS_CB_SLOT, &worldDiv, 1);
@@ -593,14 +598,34 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
                 D3DXVECTOR4 fogColour(float((dwFogColour >> 16) & 0xFF) / 255.0f, float((dwFogColour >> 8) & 0xFF) / 255.0f, float(dwFogColour & 0xFF) / 255.0f, 1.0f);
                 Device->SetPixelShaderConstant(WATER_FOG_COLOUR_PS_CB_SLOT, &fogColour, 1u);
 
+                Device->GetRenderState(D3DRS_FOGENABLE, &fogEnablePreserve);
+                Device->GetRenderState(D3DRS_FOGTABLEMODE, &fogModePreserve);
+
                 Device->SetRenderState(D3DRS_FOGENABLE, TRUE);
                 Device->SetRenderState(D3DRS_FOGTABLEMODE, D3DFOG_LINEAR);
                 forceFog = true;
 
-                IDirect3DBaseTexture8* tex = GetCutsceneID() == CS_END_LEAVE_LETTER ? GetTexture(kCemeteryLeaveTextureId) : GetTexture(kExteriorWaterTextureId);
+                IDirect3DBaseTexture8* tex = nullptr;
+                switch (GetCutsceneID())
+                {
+                case CS_END_LEAVE_LETTER:
+                    tex = GetTexture(kCemeteryLeaveTextureId);
+                    break;
+                case CS_END_REBIRTH_EPILOGUE:
+                    tex = GetTexture(kLakeRebirthTextureId);
+                    break;
+                default:
+                    tex = GetTexture(kExteriorWaterTextureId);
+                }
                 if (tex != nullptr)
                 {
                     Device->SetTexture(WATER_TEXTURE_SLOT_BASE, tex);
+
+                    Device->SetTextureStageState(WATER_TEXTURE_SLOT_BASE, D3DTSS_ADDRESSU, D3DTADDRESS_WRAP);
+                    Device->SetTextureStageState(WATER_TEXTURE_SLOT_BASE, D3DTSS_ADDRESSV, D3DTADDRESS_WRAP);
+                    Device->SetTextureStageState(WATER_TEXTURE_SLOT_BASE, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
+                    Device->SetTextureStageState(WATER_TEXTURE_SLOT_BASE, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
+                    Device->SetTextureStageState(WATER_TEXTURE_SLOT_BASE, D3DTSS_MIPFILTER, D3DTEXF_LINEAR);
                 }
 
                 D3DXVECTOR4 uvOffset = GetBaseUVOffset(roomID, inGameTimerMs, Device);
@@ -611,7 +636,13 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
             Device->SetPixelShaderConstant(WATER_DUDV_SPEC_SCALE_PS_CB_SLOT, &dudvSpecScale, 1u);
             Device->SetPixelShaderConstant(WATER_SPEC_MULT_PS_CB_SLOT, &specMult, 1u);
 
-            HRESULT hr = Device->DrawPrimitiveUP(PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
+            HRESULT hr = DrawFunc();
+
+            if (forceFog)
+            {
+                Device->SetRenderState(D3DRS_FOGENABLE, fogEnablePreserve);
+                Device->SetRenderState(D3DRS_FOGTABLEMODE, fogModePreserve);
+            }
 
             Device->SetVertexShader(currVS);
             Device->SetPixelShader(currPS);

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -44,6 +44,7 @@ static DWORD g_cemeteryWaterPlaneCheckValue = NULL;
 #define WATER_UVMUL_VS_CB_SLOT              91
 #define WATER_WORLD_VS_CB_SLOT              92
 #define WATER_COLOUR_VS_CB_SLOT             93
+#define WATER_UVOFFS_VS_CB_SLOT             94
 
 /*
 vs.1.1
@@ -80,6 +81,8 @@ m4x4 r0, v0, c32
 mov oPos, r0
 // make main UVs by using world pos
 mul r1, v0.xzzz, c92
+// offset UVs by water pos
+add r1, r1.xy, c94.xy
 // pass-through UVs
 mov oT0, r1
 // animate UVs for the DuDv map
@@ -98,7 +101,8 @@ DWORD g_WaterPondVSBytecode[] = {
     0x69737265, 0x30206e6f, 0x0031392e, 0x00000014,
     0x800f0000, 0x90e40000, 0xa0e40020, 0x00000001,
     0xc00f0000, 0x80e40000, 0x00000005, 0x800f0001,
-    0x90a80000, 0xa0e4005c, 0x00000001, 0xe00f0000,
+    0x90a80000, 0xa0e4005c, 0x00000002, 0x800f0001,
+    0x80540001, 0xa054005e, 0x00000001, 0xe00f0000,
     0x80e40001, 0x00000002, 0xe00f0001, 0x80e40001,
     0xa0e4005a, 0x00000001, 0xe00f0002, 0x80e40000,
     0x00000005, 0xe00f0003, 0x80e40001, 0xa0e4005b,
@@ -350,9 +354,9 @@ static bool CheckWaterPrimitivesCountByRoom(const UINT PrimitiveCount) {
             isWater = (PrimitiveCount == 102u);
         break;
         // Lake
-        //case R_TOWN_LAKE:
-        //    isWater = (PrimitiveCount == 68u);
-        //break;
+        case R_TOWN_LAKE:
+            isWater = (PrimitiveCount == 68u);
+        break;
         // Pyramidhead submerge
         case R_APT_W_STAIRCASE_N:
             isWater = (PrimitiveCount == 38u);
@@ -404,6 +408,14 @@ static void GetWaterConstantsByRoom(D3DXVECTOR4& specMult, D3DXVECTOR4& specUvMu
             specUvMult = { water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery };
         }
         break;
+        // Lake
+        case R_TOWN_LAKE:
+        {
+            dudvScale = { 0.005f, 0.005f, 0.005f, 0.005f };
+            const float specMultOverride = water_spec_mult_cemetery;
+            specMult = { specMultOverride, specMultOverride, specMultOverride, 0.0f };
+            specUvMult = { water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery };
+        }
         // Pyramidhead submerge
         case R_APT_W_STAIRCASE_N:
             specMult = { water_spec_mult_apt_staircase, water_spec_mult_apt_staircase, water_spec_mult_apt_staircase, 0.0f };
@@ -443,7 +455,7 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
 
     const DWORD roomID = GetRoomID();
 
-    if ((colorOp0 == D3DTOP_MODULATE2X || roomID == R_FOREST_CEMETERY) && PrimitiveType == D3DPT_TRIANGLESTRIP && CheckWaterPrimitivesCountByRoom(PrimitiveCount) && VertexStreamZeroStride == 24u && pVertexStreamZeroData != nullptr) {
+    if ((colorOp0 == D3DTOP_MODULATE2X || roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) && PrimitiveType == D3DPT_TRIANGLESTRIP && CheckWaterPrimitivesCountByRoom(PrimitiveCount) && VertexStreamZeroStride == 24u && pVertexStreamZeroData != nullptr) {
         DWORD currVS = 0u;
         Device->GetVertexShader(&currVS);
         DWORD currPS = 0u;
@@ -471,8 +483,8 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
             Device->GetTexture(WATER_TEXTURE_SLOT_DUDV, &tex1);
             Device->GetTexture(WATER_TEXTURE_SLOT_CAUSTICS, &tex2);
 
-            Device->SetVertexShader((roomID == R_FOREST_CEMETERY) ? g_WaterPondVSHandle : g_WaterVSHandle);
-            Device->SetPixelShader((roomID == R_FOREST_CEMETERY) ? g_WaterPondPSHandle : g_WaterPSHandle);
+            Device->SetVertexShader((roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) ? g_WaterPondVSHandle : g_WaterVSHandle);
+            Device->SetPixelShader((roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) ? g_WaterPondPSHandle : g_WaterPSHandle);
 
             Device->SetTexture(WATER_TEXTURE_SLOT_REFRACTION, g_ScreenCopyTexture);
             Device->SetTexture(WATER_TEXTURE_SLOT_DUDV, g_DuDvTexture);
@@ -508,10 +520,17 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
             Device->SetVertexShaderConstant(WATER_UVMUL_VS_CB_SLOT, &specUvMult, 1);
 
             bool forceFog = false;
-            if (roomID == R_FOREST_CEMETERY) {
+            if (roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) {
                 const float worldScale = 1.0f / 3000.0f;
                 D3DXVECTOR4 worldDiv = { worldScale, worldScale, worldScale, worldScale };
                 Device->SetVertexShaderConstant(WATER_WORLD_VS_CB_SLOT, &worldDiv, 1);
+
+                if (roomID == R_TOWN_LAKE) {
+                    D3DXMATRIX transform;
+                    Device->GetTransform(D3DTS_WORLDMATRIX(0), &transform);
+                    D3DXVECTOR4 uvOffset = { transform.m[3][0] * worldScale, transform.m[3][2] * worldScale, 0.0f, 0.0f };
+                    Device->SetVertexShaderConstant(WATER_UVOFFS_VS_CB_SLOT, &uvOffset, 1);
+                }
 
                 D3DXVECTOR4 waterColour = { 0.32f, 0.32f, 0.32f, 0.35f };
                 Device->SetVertexShaderConstant(WATER_COLOUR_VS_CB_SLOT, &waterColour, 1);

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -585,10 +585,17 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
             Device->SetVertexShaderConstant(WATER_UVADD_VS_CB_SLOT, &uvAddition, 1);
             Device->SetVertexShaderConstant(WATER_UVMUL_VS_CB_SLOT, &specUvMult, 1);
 
-            D3DXVECTOR4 uvOffset{ 0.0f, 0.0f, 0.0f, 0.0f };
-            bool forceFog = false;
             DWORD fogEnablePreserve = 0;
             DWORD fogModePreserve = 0;
+
+            Device->GetRenderState(D3DRS_FOGENABLE, &fogEnablePreserve);
+            Device->GetRenderState(D3DRS_FOGTABLEMODE, &fogModePreserve);
+
+            Device->SetRenderState(D3DRS_FOGENABLE, TRUE);
+            Device->SetRenderState(D3DRS_FOGTABLEMODE, D3DFOG_LINEAR);
+
+            D3DXVECTOR4 uvOffset{ 0.0f, 0.0f, 0.0f, 0.0f };
+            
             if (roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) {
                 D3DXVECTOR4 worldDiv = { kWorldScale, kWorldScale, kWorldScale, kWorldScale };
                 Device->SetVertexShaderConstant(WATER_WORLD_VS_CB_SLOT, &worldDiv, 1);
@@ -600,13 +607,6 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
                 Device->GetRenderState(D3DRS_FOGCOLOR, &dwFogColour);
                 D3DXVECTOR4 fogColour(float((dwFogColour >> 16) & 0xFF) / 255.0f, float((dwFogColour >> 8) & 0xFF) / 255.0f, float(dwFogColour & 0xFF) / 255.0f, 1.0f);
                 Device->SetPixelShaderConstant(WATER_FOG_COLOUR_PS_CB_SLOT, &fogColour, 1u);
-
-                Device->GetRenderState(D3DRS_FOGENABLE, &fogEnablePreserve);
-                Device->GetRenderState(D3DRS_FOGTABLEMODE, &fogModePreserve);
-
-                Device->SetRenderState(D3DRS_FOGENABLE, TRUE);
-                Device->SetRenderState(D3DRS_FOGTABLEMODE, D3DFOG_LINEAR);
-                forceFog = true;
 
                 IDirect3DBaseTexture8* tex = nullptr;
                 const DWORD cutsceneID = GetCutsceneID();
@@ -642,11 +642,8 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
 
             HRESULT hr = DrawFunc();
 
-            if (forceFog)
-            {
-                Device->SetRenderState(D3DRS_FOGENABLE, fogEnablePreserve);
-                Device->SetRenderState(D3DRS_FOGTABLEMODE, fogModePreserve);
-            }
+            Device->SetRenderState(D3DRS_FOGENABLE, fogEnablePreserve);
+            Device->SetRenderState(D3DRS_FOGTABLEMODE, fogModePreserve);
 
             Device->SetVertexShader(currVS);
             Device->SetPixelShader(currPS);

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -495,28 +495,14 @@ D3DXVECTOR4 GetBaseUVOffset(DWORD roomID, DWORD cutsceneID, int64_t inGameTimerM
     if (roomID != R_FOREST_CEMETERY && roomID != R_TOWN_LAKE)
         return uvOffset;
 
-    const int mode = roomID == R_FOREST_CEMETERY ? water_uv_mode_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_mode_lake_rebirth : water_uv_mode_lake;
-    if (mode == 0) {
-        const double speed = roomID == R_FOREST_CEMETERY ? water_uv_rot_speed_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_rot_speed_lake_rebirth : water_uv_rot_speed_lake;
-        const double radius = roomID == R_FOREST_CEMETERY ? water_uv_rot_radius_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_rot_radius_lake_rebirth : water_uv_rot_radius_lake;
-        const double theta = static_cast<double>(inGameTimerMs) * speed * kPi / 1000.0;
-        uvOffset = {
-            static_cast<float>(std::sin(theta) * radius * kWorldScale),
-            static_cast<float>(std::cos(theta) * radius * kWorldScale),
-            0.0f,
-            0.0f
-        };
-    }
-    else {
-        const double speedU = roomID == R_FOREST_CEMETERY ? water_uv_scroll_u_speed_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_scroll_u_speed_lake_rebirth : water_uv_scroll_u_speed_lake;
-        const double speedV = roomID == R_FOREST_CEMETERY ? water_uv_scroll_v_speed_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_scroll_v_speed_lake_rebirth : water_uv_scroll_v_speed_lake;
-        uvOffset = {
-            static_cast<float>(GetFracPart(static_cast<double>(inGameTimerMs) * 0.00005 * speedU) * 20.0),
-            static_cast<float>(GetFracPart(static_cast<double>(inGameTimerMs) * 0.00005 * speedV) * 20.0),
-            0.0f,
-            0.0f
-        };
-    }
+    const double speedU = roomID == R_FOREST_CEMETERY ? water_uv_scroll_u_speed_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_scroll_u_speed_lake_rebirth : water_uv_scroll_u_speed_lake;
+    const double speedV = roomID == R_FOREST_CEMETERY ? water_uv_scroll_v_speed_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_scroll_v_speed_lake_rebirth : water_uv_scroll_v_speed_lake;
+    uvOffset = {
+        static_cast<float>(GetFracPart(static_cast<double>(inGameTimerMs) * 0.00005 * speedU) * 20.0),
+        static_cast<float>(GetFracPart(static_cast<double>(inGameTimerMs) * 0.00005 * speedV) * 20.0),
+        0.0f,
+        0.0f
+    };
     if (roomID == R_TOWN_LAKE && GetCutsceneID() != CS_END_REBIRTH_EPILOGUE) {
         D3DXMATRIX transform;
         Device->GetTransform(D3DTS_WORLDMATRIX(0), &transform);

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -28,6 +28,8 @@ static DWORD* g_vsHandles = nullptr;
 static DWORD* g_cemeteryWaterPlaneCheckAddr = nullptr;
 static DWORD g_cemeteryWaterPlaneCheckValue = NULL;
 
+constexpr float kLakeWaterCullDistZ = -8000.0f;
+
 #define WATER_VSHADER_ORIGINAL  (g_vsHandles[3])
 #define WATER_FVF               (D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1)
 
@@ -590,6 +592,18 @@ void PatchWaterEnhancement()
         WaterEnhancedRender = false;
         return;
     }
+
+    // Increase distance after which the lake water disappears when James leaves the hotel dock
+    constexpr BYTE SearchBytes[]{ 0x83, 0xC4, 0x10, 0xEB, 0x06, 0xC7, 0x07, 0x01, 0x00, 0x00, 0x00 };
+    DWORD LakeWaterCullDistZAddr = SearchAndGetAddresses(0x004D5768, 0x004D5A18, 0x004D52D8, SearchBytes, sizeof(SearchBytes), 0x11, __FUNCTION__);
+    if (!LakeWaterCullDistZAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find pointer address!";
+        WaterEnhancedRender = false;
+        return;
+    }
+    const float* LakeWaterCullDistZ = &kLakeWaterCullDistZ;
+    UpdateMemoryAddress((void*)LakeWaterCullDistZAddr, &LakeWaterCullDistZ, sizeof(float));
 }
 
 void CheckCemeteryWaterCulling()

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -415,7 +415,7 @@ static void GetWaterConstantsByRoom(D3DXVECTOR4& specMult, D3DXVECTOR4& specUvMu
         case R_FOREST_CEMETERY:
         {
             dudvScale = { 0.005f, 0.005f, 0.005f, 0.005f };
-            const float specMultOverride = (GetCutsceneID() == CS_END_LEAVE_LETTER) ? 0.075f : water_spec_mult_cemetery;
+            const float specMultOverride = (GetCutsceneID() == CS_END_LEAVE_LETTER) ? 0.05f : water_spec_mult_cemetery;
             specMult = { specMultOverride, specMultOverride, specMultOverride, 0.0f };
             specUvMult = { water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery, water_spec_uv_mult_cemetery };
         }

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -330,8 +330,8 @@ static void LoadWaterUtilityTextures(LPDIRECT3DDEVICE8 Device) {
     }
 }
 
-static float GetFracPart(float f) {
-    return f - std::floorf(f);
+static double GetFracPart(double f) {
+    return f - std::floor(f);
 }
 
 static void SaveTextureStates(LPDIRECT3DDEVICE8 Device, const DWORD stage, DWORD* saveTo) {
@@ -484,7 +484,7 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
             }
             LoadWaterUtilityTextures(Device);
 
-            const float fraction = GetFracPart(static_cast<float>(inGameTimerMs) * 0.00005f);
+            const float fraction = static_cast<float>(GetFracPart(static_cast<double>(inGameTimerMs) * 0.00005));
             const D3DXVECTOR4 uvAddition(fraction, fraction, fraction, fraction);
 
             D3DXVECTOR4 specMult;

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -362,10 +362,24 @@ static void RestoreTextureStates(LPDIRECT3DDEVICE8 Device, const DWORD stage, co
     Device->SetTextureStageState(stage, D3DTSS_MIPFILTER, loadFrom[4]);
 }
 
-static bool CheckWaterPrimitivesCountByRoom(const UINT PrimitiveCount) {
+static bool CheckWaterPrimitivesCountByRoom(const UINT PrimitiveCount, bool DrawUP) {
     bool isWater = false;
 
     const DWORD roomID = GetRoomID();
+
+    if (!DrawUP) {
+        switch (roomID) {
+            // Lake
+            case R_TOWN_LAKE:
+                isWater = (PrimitiveCount == 104u && GetCutsceneID() == CS_END_REBIRTH_EPILOGUE);
+            break;
+            // Town East (along entrance road)
+            case R_TOWN_EAST:
+                isWater = (PrimitiveCount == 104u);
+            break;
+        }
+        return isWater;
+    }
 
     switch (roomID) {
         // Pond
@@ -374,11 +388,8 @@ static bool CheckWaterPrimitivesCountByRoom(const UINT PrimitiveCount) {
         break;
         // Lake
         case R_TOWN_LAKE:
-            isWater = (PrimitiveCount == 68u || PrimitiveCount == 104u);
+            isWater = (PrimitiveCount == 68u);
         break;
-        case R_TOWN_EAST:
-            isWater = (PrimitiveCount == 104u);
-            break;
         // Pyramidhead submerge
         case R_APT_W_STAIRCASE_N:
             isWater = (PrimitiveCount == 38u);
@@ -512,13 +523,13 @@ D3DXVECTOR4 GetBaseUVOffset(DWORD roomID, DWORD cutsceneID, int64_t inGameTimerM
     return uvOffset;
 }
 
-HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 Device, LPDIRECT3DSURFACE8 backBufferSurface, UINT PrimitiveCount, std::function<HRESULT()> DrawFunc) {
+HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 Device, LPDIRECT3DSURFACE8 backBufferSurface, UINT PrimitiveCount, bool DrawUP, std::function<HRESULT()> DrawFunc) {
     DWORD colorOp0 = 0;
     Device->GetTextureStageState(0, D3DTSS_COLOROP, &colorOp0);
 
     const DWORD roomID = GetRoomID();
 
-    if ((colorOp0 == D3DTOP_MODULATE2X || roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE || roomID == R_TOWN_EAST) && CheckWaterPrimitivesCountByRoom(PrimitiveCount)) {
+    if ((colorOp0 == D3DTOP_MODULATE2X || roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE || roomID == R_TOWN_EAST) && CheckWaterPrimitivesCountByRoom(PrimitiveCount, DrawUP)) {
         DWORD currVS = 0u;
         Device->GetVertexShader(&currVS);
         DWORD currPS = 0u;

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -65,14 +65,16 @@ vs.1.1
 // to clip pos
 m4x4 r0, v0, c32
 mov oPos, r0
+// apply base UV offset
+add r1, v7.xy, c94.xy
 // pass-through UVs
-mov oT0, v7
+mov oT0, r1
 // animate UVs for the DuDv map
-add oT1, v7, c90
+add oT1, r1, c90
 // pass our ptojected pos for the refraction perspective UVs
 mov oT2, r0
 // scale caustics UVs
-mul oT3, v7, c91
+mul oT3, r1, c91
 // pass-through vertex colour
 mov oD0, v5
 */
@@ -81,10 +83,11 @@ DWORD g_WaterVSBytecode[] = {
     0x72656461, 0x73734120, 0x6c626d65, 0x56207265,
     0x69737265, 0x30206e6f, 0x0031392e, 0x00000014,
     0x800f0000, 0x90e40000, 0xa0e40020, 0x00000001,
-    0xc00f0000, 0x80e40000, 0x00000001, 0xe00f0000,
-    0x90e40007, 0x00000002, 0xe00f0001, 0x90e40007,
+    0xc00f0000, 0x80e40000, 0x00000002, 0x800f0001,
+    0x90540007, 0xa054005e, 0x00000001, 0xe00f0000,
+    0x80e40001, 0x00000002, 0xe00f0001, 0x80e40001,
     0xa0e4005a, 0x00000001, 0xe00f0002, 0x80e40000,
-    0x00000005, 0xe00f0003, 0x90e40007, 0xa0e4005b,
+    0x00000005, 0xe00f0003, 0x80e40001, 0xa0e4005b,
     0x00000001, 0xd00f0000, 0x90e40005, 0x0000ffff
 };
 
@@ -95,7 +98,7 @@ m4x4 r0, v0, c32
 mov oPos, r0
 // make main UVs by using world pos
 mul r1, v0.xzzz, c92
-// offset UVs by water pos
+// apply base UV offset
 add r1, r1.xy, c94.xy
 // pass-through UVs
 mov oT0, r1
@@ -474,16 +477,16 @@ IDirect3DBaseTexture8* GetTexture(UINT id)
     return (IDirect3DBaseTexture8*)*(DWORD*)(texturePtr + 0x8C);
 }
 
-D3DXVECTOR4 GetBaseUVOffset(DWORD roomID, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 Device) {
+D3DXVECTOR4 GetBaseUVOffset(DWORD roomID, DWORD cutsceneID, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 Device) {
     D3DXVECTOR4 uvOffset;
 
     if (roomID != R_FOREST_CEMETERY && roomID != R_TOWN_LAKE)
         return uvOffset;
 
-    const int mode = roomID == R_FOREST_CEMETERY ? water_uv_mode_cemetery : water_uv_mode_lake;
+    const int mode = roomID == R_FOREST_CEMETERY ? water_uv_mode_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_mode_lake_rebirth : water_uv_mode_lake;
     if (mode == 0) {
-        const double speed = roomID == R_FOREST_CEMETERY ? water_uv_rot_speed_cemetery : water_uv_rot_speed_lake;
-        const double radius = roomID == R_FOREST_CEMETERY ? water_uv_rot_radius_cemetery : water_uv_rot_radius_lake;
+        const double speed = roomID == R_FOREST_CEMETERY ? water_uv_rot_speed_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_rot_speed_lake_rebirth : water_uv_rot_speed_lake;
+        const double radius = roomID == R_FOREST_CEMETERY ? water_uv_rot_radius_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_rot_radius_lake_rebirth : water_uv_rot_radius_lake;
         const double theta = static_cast<double>(inGameTimerMs) * speed * kPi / 1000.0;
         uvOffset = {
             static_cast<float>(std::sin(theta) * radius * kWorldScale),
@@ -493,10 +496,9 @@ D3DXVECTOR4 GetBaseUVOffset(DWORD roomID, int64_t inGameTimerMs, LPDIRECT3DDEVIC
         };
     }
     else {
-        const double speedU = roomID == R_FOREST_CEMETERY ? water_uv_scroll_u_speed_cemetery : water_uv_scroll_u_speed_lake;
-        const double speedV = roomID == R_FOREST_CEMETERY ? water_uv_scroll_v_speed_cemetery : water_uv_scroll_v_speed_lake;
+        const double speedU = roomID == R_FOREST_CEMETERY ? water_uv_scroll_u_speed_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_scroll_u_speed_lake_rebirth : water_uv_scroll_u_speed_lake;
+        const double speedV = roomID == R_FOREST_CEMETERY ? water_uv_scroll_v_speed_cemetery : cutsceneID == CS_END_REBIRTH_EPILOGUE ? water_uv_scroll_v_speed_lake_rebirth : water_uv_scroll_v_speed_lake;
         uvOffset = {
-            // static_cast<float>(inGameTimerMs) * 0.00005f * speed,
             static_cast<float>(GetFracPart(static_cast<double>(inGameTimerMs) * 0.00005 * speedU) * 20.0),
             static_cast<float>(GetFracPart(static_cast<double>(inGameTimerMs) * 0.00005 * speedV) * 20.0),
             0.0f,
@@ -583,6 +585,7 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
             Device->SetVertexShaderConstant(WATER_UVADD_VS_CB_SLOT, &uvAddition, 1);
             Device->SetVertexShaderConstant(WATER_UVMUL_VS_CB_SLOT, &specUvMult, 1);
 
+            D3DXVECTOR4 uvOffset;
             bool forceFog = false;
             DWORD fogEnablePreserve = 0;
             DWORD fogModePreserve = 0;
@@ -606,7 +609,8 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
                 forceFog = true;
 
                 IDirect3DBaseTexture8* tex = nullptr;
-                switch (GetCutsceneID())
+                const DWORD cutsceneID = GetCutsceneID();
+                switch (cutsceneID)
                 {
                 case CS_END_LEAVE_LETTER:
                     tex = GetTexture(kCemeteryLeaveTextureId);
@@ -628,13 +632,13 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
                     Device->SetTextureStageState(WATER_TEXTURE_SLOT_BASE, D3DTSS_MIPFILTER, D3DTEXF_LINEAR);
                 }
 
-                D3DXVECTOR4 uvOffset = GetBaseUVOffset(roomID, inGameTimerMs, Device);
-                Device->SetVertexShaderConstant(WATER_UVOFFS_VS_CB_SLOT, &uvOffset, 1);
+                uvOffset = GetBaseUVOffset(roomID, cutsceneID, inGameTimerMs, Device);
             }
 
             Device->SetPixelShaderConstant(WATER_DUDV_SCALE_PS_CB_SLOT, &dudvScale, 1u);
             Device->SetPixelShaderConstant(WATER_DUDV_SPEC_SCALE_PS_CB_SLOT, &dudvSpecScale, 1u);
             Device->SetPixelShaderConstant(WATER_SPEC_MULT_PS_CB_SLOT, &specMult, 1u);
+            Device->SetVertexShaderConstant(WATER_UVOFFS_VS_CB_SLOT, &uvOffset, 1);
 
             HRESULT hr = DrawFunc();
 

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -35,6 +35,7 @@ BYTE*(*shGetTexture)(UINT);
 
 constexpr double kPi = 3.141592653589793;
 constexpr UINT kExteriorWaterTextureId = 0x52F6;
+constexpr UINT kCemeteryLeaveTextureId = 0x52F7;
 constexpr float kWorldScale = 1.0f / 3000.0f;
 constexpr float kLakeWaterCullDistZ = -8000.0f;
 
@@ -596,7 +597,8 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
                 Device->SetRenderState(D3DRS_FOGTABLEMODE, D3DFOG_LINEAR);
                 forceFog = true;
 
-                if (auto* tex = GetTexture(kExteriorWaterTextureId); tex != nullptr)
+                IDirect3DBaseTexture8* tex = GetCutsceneID() == CS_END_LEAVE_LETTER ? GetTexture(kCemeteryLeaveTextureId) : GetTexture(kExteriorWaterTextureId);
+                if (tex != nullptr)
                 {
                     Device->SetTexture(WATER_TEXTURE_SLOT_BASE, tex);
                 }
@@ -719,10 +721,21 @@ void UpdateExteriorWaterVertexColors()
         return;
 
     const DWORD roomID = GetRoomID();
-    if (g_cemeteryWaterRGB && g_cemeteryWaterAlpha && roomID == R_FOREST_CEMETERY && GetTexture(kExteriorWaterTextureId) != nullptr)
+    if (g_cemeteryWaterRGB && g_cemeteryWaterAlpha && roomID == R_FOREST_CEMETERY)
     {
-        g_cemeteryWaterRGB[0] = g_cemeteryWaterRGB[1] = g_cemeteryWaterRGB[2] = water_rgb_cemetery;
-        *g_cemeteryWaterAlpha = water_alpha_cemetery;
+        if (GetCutsceneID() == CS_END_LEAVE_LETTER)
+        {
+            if (GetTexture(kCemeteryLeaveTextureId) != nullptr)
+            {
+                g_cemeteryWaterRGB[0] = g_cemeteryWaterRGB[1] = g_cemeteryWaterRGB[2] = 128.0f;
+                *g_cemeteryWaterAlpha = water_alpha_cemetery;
+            }
+        }
+        else if (GetTexture(kExteriorWaterTextureId) != nullptr)
+        {
+            g_cemeteryWaterRGB[0] = g_cemeteryWaterRGB[1] = g_cemeteryWaterRGB[2] = water_rgb_cemetery;
+            *g_cemeteryWaterAlpha = water_alpha_cemetery;
+        }
     }
     if (g_lakeWaterRGBA && roomID == R_TOWN_LAKE && GetTexture(kExteriorWaterTextureId) != nullptr)
     {

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -376,6 +376,9 @@ static bool CheckWaterPrimitivesCountByRoom(const UINT PrimitiveCount) {
         case R_TOWN_LAKE:
             isWater = (PrimitiveCount == 68u || PrimitiveCount == 104u);
         break;
+        case R_TOWN_EAST:
+            isWater = (PrimitiveCount == 104u);
+            break;
         // Pyramidhead submerge
         case R_APT_W_STAIRCASE_N:
             isWater = (PrimitiveCount == 38u);
@@ -433,6 +436,14 @@ static void GetWaterConstantsByRoom(D3DXVECTOR4& specMult, D3DXVECTOR4& specUvMu
             dudvScale = { 0.005f, 0.005f, 0.005f, 0.005f };
             specMult = { water_spec_mult_lake, water_spec_mult_lake, water_spec_mult_lake, 0.0f };
             specUvMult = { water_spec_uv_mult_lake, water_spec_uv_mult_lake, water_spec_uv_mult_lake, water_spec_uv_mult_lake };
+        }
+        break;
+        // Town East (along entrance road)
+        case R_TOWN_EAST:
+        {
+            dudvScale = { 0.005f, 0.005f, 0.005f, 0.005f };
+            specMult = { water_spec_mult_town_east, water_spec_mult_town_east, water_spec_mult_town_east, 0.0f };
+            specUvMult = { water_spec_uv_mult_town_east, water_spec_uv_mult_town_east, water_spec_uv_mult_town_east, water_spec_uv_mult_town_east };
         }
         break;
         // Pyramidhead submerge
@@ -521,7 +532,7 @@ HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, 
 
     const DWORD roomID = GetRoomID();
 
-    if ((colorOp0 == D3DTOP_MODULATE2X || roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE) && CheckWaterPrimitivesCountByRoom(PrimitiveCount)) {
+    if ((colorOp0 == D3DTOP_MODULATE2X || roomID == R_FOREST_CEMETERY || roomID == R_TOWN_LAKE || roomID == R_TOWN_EAST) && CheckWaterPrimitivesCountByRoom(PrimitiveCount)) {
         DWORD currVS = 0u;
         Device->GetVertexShader(&currVS);
         DWORD currPS = 0u;

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -221,8 +221,8 @@ phase
   texld r1, r3
   // sample caustics texture
   texld r3, r5
-  // tint water texture by the vertex colour (x2)
-  mul r0, r0, v0_x2
+  // tint water texture by the vertex colour
+  mul r0, r0, v0
   // blend them
   lrp_sat r0, r0.w, r0, r1
   // add modulated caustics
@@ -248,7 +248,7 @@ DWORD g_WaterPondPSBytecode[] = {
     0x0000fffd, 0x00000042, 0x800f0000, 0x80e40002,
     0x00000042, 0x800f0001, 0x80e40003, 0x00000042,
     0x800f0003, 0x80e40005, 0x00000005, 0x800f0000,
-    0x80e40000, 0x97e40000, 0x00000012, 0x801f0000,
+    0x80e40000, 0x90e40000, 0x00000012, 0x801f0000,
     0x80ff0000, 0x80e40000, 0x80e40001, 0x00000004,
     0x801f0000, 0x80e40003, 0xa0e40006, 0x80e40000,
     0x00000001, 0x80080000, 0xa0e40000, 0x0000ffff,

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -52,7 +52,7 @@ extern DWORD g_WaterPSBytecode[];
 extern DWORD g_WaterPondPSBytecode[];
 extern DWORD vsDeclWater[];
 extern void WaterEnhancedReleaseScreenCopy();
-extern HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 ProxyInterface, LPDIRECT3DSURFACE8 pRenderTarget, UINT PrimitiveCount, std::function<HRESULT()> DrawFunc);
+extern HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 ProxyInterface, LPDIRECT3DSURFACE8 pRenderTarget, UINT PrimitiveCount, bool DrawUP, std::function<HRESULT()> DrawFunc);
 
 // roaches replacement
 static float sFrameTimeInSeconds = 0.0f;
@@ -2175,7 +2175,7 @@ HRESULT m_IDirect3DDevice8::DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT S
 		{
 			backBufferSurface = ProxyAddressLookupTableD3d8->FindAddress<m_IDirect3DSurface8>(backBufferSurface);
 		}
-		HRESULT hr = DrawWaterEnhanced(NeedToGrabScreenForWater, InGameTimerMs, this, backBufferSurface, PrimitiveCount, [&]() { return ProxyInterface->DrawPrimitive(PrimitiveType, StartVertex, PrimitiveCount); });
+		HRESULT hr = DrawWaterEnhanced(NeedToGrabScreenForWater, InGameTimerMs, this, backBufferSurface, PrimitiveCount, /*DrawUP=*/false, [&]() { return ProxyInterface->DrawPrimitive(PrimitiveType, StartVertex, PrimitiveCount); });
 		if (backBufferSurface)
 		{
 			backBufferSurface->Release();
@@ -2601,7 +2601,7 @@ HRESULT m_IDirect3DDevice8::DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT
 		{
 			backBufferSurface = ProxyAddressLookupTableD3d8->FindAddress<m_IDirect3DSurface8>(backBufferSurface);
 		}
-		HRESULT hr = DrawWaterEnhanced(NeedToGrabScreenForWater, InGameTimerMs, this, backBufferSurface, PrimitiveCount, [&]() { return ProxyInterface->DrawPrimitiveUP(PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride); });
+		HRESULT hr = DrawWaterEnhanced(NeedToGrabScreenForWater, InGameTimerMs, this, backBufferSurface, PrimitiveCount, /*DrawUP=*/true, [&]() { return ProxyInterface->DrawPrimitiveUP(PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride); });
 		if (backBufferSurface)
 		{
 			backBufferSurface->Release();

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -21,6 +21,7 @@
 #include <array>
 #include <deque>
 #include <ctime>
+#include <functional>
 #include <numeric>
 #include "Common\Utils.h"
 #include "stb_image.h"
@@ -51,7 +52,7 @@ extern DWORD g_WaterPSBytecode[];
 extern DWORD g_WaterPondPSBytecode[];
 extern DWORD vsDeclWater[];
 extern void WaterEnhancedReleaseScreenCopy();
-extern HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 ProxyInterface, LPDIRECT3DSURFACE8 pRenderTarget, D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void* pVertexStreamZeroData, UINT VertexStreamZeroStride);
+extern HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 ProxyInterface, LPDIRECT3DSURFACE8 pRenderTarget, UINT PrimitiveCount, std::function<HRESULT()> DrawFunc);
 
 // roaches replacement
 static float sFrameTimeInSeconds = 0.0f;
@@ -2167,6 +2168,25 @@ HRESULT m_IDirect3DDevice8::DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT S
         }
     }
 
+	if (WaterEnhancedRender && PrimitiveType == D3DPT_TRIANGLESTRIP && GetCutsceneID() == CS_END_REBIRTH_EPILOGUE)
+	{
+		LPDIRECT3DSURFACE8 backBufferSurface = nullptr;
+		if (SUCCEEDED(ProxyInterface->GetRenderTarget(&backBufferSurface)))
+		{
+			backBufferSurface = ProxyAddressLookupTableD3d8->FindAddress<m_IDirect3DSurface8>(backBufferSurface);
+		}
+		HRESULT hr = DrawWaterEnhanced(NeedToGrabScreenForWater, InGameTimerMs, this, backBufferSurface, PrimitiveCount, [&]() { return ProxyInterface->DrawPrimitive(PrimitiveType, StartVertex, PrimitiveCount); });
+		if (backBufferSurface)
+		{
+			backBufferSurface->Release();
+		}
+		if (hr != -1)
+		{
+			NeedToGrabScreenForWater = false;
+			return hr;
+		}
+	}
+
 	return ProxyInterface->DrawPrimitive(PrimitiveType, StartVertex, PrimitiveCount);
 }
 
@@ -2574,14 +2594,14 @@ HRESULT m_IDirect3DDevice8::DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT
 		}
 	}
 
-	if (WaterEnhancedRender)
+	if (WaterEnhancedRender && PrimitiveType == D3DPT_TRIANGLESTRIP && VertexStreamZeroStride == 24u && pVertexStreamZeroData != nullptr)
 	{
 		LPDIRECT3DSURFACE8 backBufferSurface = nullptr;
 		if (SUCCEEDED(ProxyInterface->GetRenderTarget(&backBufferSurface)))
 		{
 			backBufferSurface = ProxyAddressLookupTableD3d8->FindAddress<m_IDirect3DSurface8>(backBufferSurface);
 		}
-		HRESULT hr = DrawWaterEnhanced(NeedToGrabScreenForWater, InGameTimerMs, this, backBufferSurface, PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
+		HRESULT hr = DrawWaterEnhanced(NeedToGrabScreenForWater, InGameTimerMs, this, backBufferSurface, PrimitiveCount, [&]() { return ProxyInterface->DrawPrimitiveUP(PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride); });
 		if (backBufferSurface)
 		{
 			backBufferSurface->Release();

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -2168,7 +2168,7 @@ HRESULT m_IDirect3DDevice8::DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT S
         }
     }
 
-	if (WaterEnhancedRender && PrimitiveType == D3DPT_TRIANGLESTRIP && GetCutsceneID() == CS_END_REBIRTH_EPILOGUE)
+	if (WaterEnhancedRender && PrimitiveType == D3DPT_TRIANGLESTRIP)
 	{
 		LPDIRECT3DSURFACE8 backBufferSurface = nullptr;
 		if (SUCCEEDED(ProxyInterface->GetRenderTarget(&backBufferSurface)))

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -51,7 +51,7 @@ extern DWORD g_WaterPSBytecode[];
 extern DWORD g_WaterPondPSBytecode[];
 extern DWORD vsDeclWater[];
 extern void WaterEnhancedReleaseScreenCopy();
-extern HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, LPDIRECT3DDEVICE8 ProxyInterface, LPDIRECT3DSURFACE8 pRenderTarget, D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void* pVertexStreamZeroData, UINT VertexStreamZeroStride);
+extern HRESULT DrawWaterEnhanced(bool needToGrabScreenForWater, int64_t inGameTimerMs, LPDIRECT3DDEVICE8 ProxyInterface, LPDIRECT3DSURFACE8 pRenderTarget, D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void* pVertexStreamZeroData, UINT VertexStreamZeroStride);
 
 // roaches replacement
 static float sFrameTimeInSeconds = 0.0f;
@@ -2578,7 +2578,7 @@ HRESULT m_IDirect3DDevice8::DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT
 		{
 			backBufferSurface = ProxyAddressLookupTableD3d8->FindAddress<m_IDirect3DSurface8>(backBufferSurface);
 		}
-		HRESULT hr = DrawWaterEnhanced(NeedToGrabScreenForWater, this, backBufferSurface, PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
+		HRESULT hr = DrawWaterEnhanced(NeedToGrabScreenForWater, InGameTimerMs, this, backBufferSurface, PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
 		if (backBufferSurface)
 		{
 			backBufferSurface->Release();
@@ -2817,6 +2817,10 @@ HRESULT m_IDirect3DDevice8::BeginScene()
 
 		NeedToGrabScreenForWater = true;
 		RoachesDrawingCounter = 0;
+
+		if (GetEventIndex() == EVENT_IN_GAME) {
+			InGameTimerMs += static_cast<int>(GetFrametime() * 1000);
+		}
 	}
 
 	if (!isInScene)

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -1729,6 +1729,9 @@ HRESULT m_IDirect3DDevice8::Present(CONST RECT* pSourceRect, CONST RECT* pDestRe
 	// Fix water plane culling in Cemetery cutscene
 	CheckCemeteryWaterCulling();
 
+	// Set cemetery and lake vertex color overrides
+	UpdateExteriorWaterVertexColors();
+
 	// Fix pause menu before drawing scaled surface
 	bool PauseMenuFlag = FixPauseMenuOnPresent();
 

--- a/Wrappers/d3d8/IDirect3DDevice8.h
+++ b/Wrappers/d3d8/IDirect3DDevice8.h
@@ -88,6 +88,9 @@ private:
 	bool OverrideTextureLoop = false;
 	bool PresentFlag = false;
 
+	// Elapsed milliseconds while in-game. Used for animating effects.
+	int64_t InGameTimerMs = 0;
+
     // Enhanced water rendering
     bool NeedToGrabScreenForWater = true;
     // Cockroaches replacement

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -365,6 +365,12 @@ void DelayedStart()
 		PatchRowboatAnimation();
 	}
 
+	// Rowboat Spawn fix at hotel dock
+	if (RowboatSpawnFix)
+	{
+		PatchRowboatSpawn();
+	}
+
 	// Catacombs Meat Room
 	if (CatacombsMeatRoomFix)
 	{

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -278,6 +278,7 @@ copy /Y "$(ProjectDir)Resources\SH2EEsetup.exe" "$(TargetDir)" &gt;nul</Command>
     <ClCompile Include="Patches\Room312FlashlightFix.cpp" />
     <ClCompile Include="Patches\RotatingMannequinGlitch.cpp" />
     <ClCompile Include="Patches\RowboatFix.cpp" />
+    <ClCompile Include="Patches\RowboatSpawn.cpp" />
     <ClCompile Include="Patches\SaveBGImage.cpp" />
     <ClCompile Include="Patches\AtticShadowFixes.cpp" />
     <ClCompile Include="Patches\ShowerRoomFlashlightFix.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -536,6 +536,9 @@
     <ClCompile Include="Patches\RainParticles.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\RowboatSpawn.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
Adding various updates to the existing enhanced water shader. This is a continuation of work done by @iOrange to apply the shader to more rooms.

- Enable the water shader for the lake, cemetery water, and water channel in Eastern South Vale.
- Apply a texture and a small UV scroll animation to the lake and cemetery water.
- Add pause support to the water shader.
- Always enable fog when rendering water.
- Increase the view distance of the lake water at the Lakeview Hotel dock to prevent the mesh from disappearing at the edge of the screen.

Also including miscellaneous related fixes:

- Add patch `RowboatSpawnFix` which respawns the boat at the Lakeview Hotel dock when reloading a save or exiting and re-entering the area.
- Adjust the min fog distance during the Rebirth ending.
- Fix a bug which may prevent the blue gem hint at the hotel dock from displaying (#1195) if a certain game condition is met.